### PR TITLE
Store location for 301 caching

### DIFF
--- a/lib/cacheable/middleware.rb
+++ b/lib/cacheable/middleware.rb
@@ -33,6 +33,8 @@ module Cacheable
 
           # Store result
           cache_data = [status, headers['Content-Type'], body_gz, timestamp]
+          cache_data << headers['Location'] if status == 301
+
           Cacheable.write_to_cache(env['cacheable.key']) do
             cache.write(env['cacheable.key'], cache_data)
             cache.write(env['cacheable.unversioned-key'], cache_data) if env['cacheable.unversioned-key']

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -110,13 +110,15 @@ module Cacheable
         @env['cacheable.miss']  = false
         @env['cacheable.store'] = 'server'
 
-        status, content_type, body, timestamp = hit
+        status, content_type, body, timestamp, location = hit
 
         if cache_age_tolerance && page_too_old(timestamp, cache_age_tolerance)
           Cacheable.log "Found an unversioned cache entry, but it was too old (#{timestamp})"
         else
           cache_return!(message) do
             response.headers['Content-Type'] = content_type
+
+            response.headers['Location'] = location if location
 
             if request.env["gzip"]
               response.headers['Content-Encoding'] = "gzip"


### PR DESCRIPTION
Fixes a bug were 301 responses were stored in the cache but the location header
was not, making the cache useless.

Not sure if this is a good idea, I'm conditionally adding the location's header value as an extra cached value.

@hornairs, @boourns 
