### PR TITLE
Remember when a request has captured the lock

### DIFF
--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -103,6 +103,16 @@ class ResponseCacheHandlerTest < MiniTest::Unit::TestCase
     assert_equal 'some text', controller.response.body
   end
 
+  def test_double_render_still_renders
+    @controller.stubs(:serve_from_browser_cache)
+    @controller.stubs(:serve_from_cache)
+    @controller.stubs(force_refill_cache?: false)
+    Cacheable.expects(:acquire_lock).once.returns(true)
+
+    handler.run!
+    handler.run!
+  end
+
   def assert_env(miss, store)
     vkh  = handler.versioned_key_hash
     uvkh = handler.unversioned_key_hash


### PR DESCRIPTION
@burke @hornairs Please review

If, halfway through a cache refill, an exception is raised and caught to render something else (for example a public-facing 404 page) that is also cacheable, we will attempt to acquire the cacheable lock multiple times in the same request.  

The first time will capture the lock, and the second time will fail, think that someone else is rendering the page, and return the unversioned copy to the end-user.

This PR memoizes when the lock is acquired so that the request with the lock will render to completion.

Net effect was if we cached a page, changed it's handle, then tried to access the same page again, the second attempt to get the lock would fail and the old copy would be served as a (recent) response from cache.
