### PR TITLE
Add some logging for uncacheable requests

### DIFF
--- a/lib/cacheable.rb
+++ b/lib/cacheable.rb
@@ -6,7 +6,6 @@ require 'cacheable/response_cache_handler'
 require 'cacheable/controller'
 
 module Cacheable
-
   def self.log(message)
     Rails.logger.info "[Cacheable] #{message}"
   end
@@ -27,11 +26,11 @@ module Cacheable
   ensure
     gz.close
   end
-  
+
   def self.decompress(content)
     Zlib::GzipReader.new(StringIO.new(content)).read
   end
-  
+
   def self.cache_key_for(data)
     case data
     when Hash, Array
@@ -46,16 +45,4 @@ module Cacheable
       data.to_s.inspect
     end
   end
-  
 end
-
-
-
-
-
-
-
-
-
-
-

--- a/lib/cacheable/controller.rb
+++ b/lib/cacheable/controller.rb
@@ -1,6 +1,6 @@
 module Cacheable
   module Controller
-    # Only get? and head? requests should be cacheable 
+    # Only get? and head? requests should be cacheable
     def cacheable_request?
       request.get? or request.head? and not request.params[:cache] == 'false'
     end
@@ -25,8 +25,11 @@ module Cacheable
     end
 
     def response_cache(key_data=nil, version_data=nil, &block)
-      return yield unless cache_configured? && cacheable_request?
-      
+      unless cache_configured? && cacheable_request?
+        Cacheable.log("Uncacheable request. cache_configured='#{!!cache_configured?}' cacheable_request='#{cacheable_request?}' params_cache='#{request.params[:cache] != 'false'}'")
+        return yield
+      end
+
       handler = Cacheable::ResponseCacheHandler.new(self) do |h|
         h.key_data       = key_data       || cache_key_data
         h.version_data   = version_data   || cache_version_data

--- a/lib/cacheable/middleware.rb
+++ b/lib/cacheable/middleware.rb
@@ -77,5 +77,4 @@ module Cacheable
       agent.browser == "Internet Explorer" && (env["HTTP_X_REQUESTED_WITH"] == "XmlHttpRequest" || env["HTTP_ACCEPT"] == "application/json")
     end
   end
-
 end

--- a/lib/cacheable/railtie.rb
+++ b/lib/cacheable/railtie.rb
@@ -6,16 +6,15 @@ module Cacheable
 
       ActionController::Base.send(:include, Cacheable::Controller)
 
-      ActiveRecord::Base.class_eval do  
+      ActiveRecord::Base.class_eval do
         def self.cache_store
           ActionController::Base.cache_store
-        end  
+        end
 
         def cache_store
           ActionController::Base.cache_store
-        end  
+        end
       end
     end
   end
-
 end


### PR DESCRIPTION
Add logging for requests that are wrapped with `response_cache` but don't actually hit the `ResponseCacheHandler` (either because cache is not configured or because caching was explicitly disabled (by setting `params[:cache]=false` or by overwriting `cacheable_request?` in a controller subclass).

With this logging added, it should get a lot easier to analyze log files and distinguish uncacheable requests from requests that do not use `response_cache` at all (the latter ones will contain no Cacheable logging, the former ones now will).

Please review @hornairs @camilo

(Travis CI passed)
