### PR TITLE
Let us have a default cache that is not the rails default

### DIFF
--- a/lib/cacheable/middleware.rb
+++ b/lib/cacheable/middleware.rb
@@ -3,6 +3,10 @@ require 'useragent'
 module Cacheable
   class Middleware
 
+    class << self
+      attr_accessor :default_cache_store
+    end
+
     def initialize(app, cache_store = nil)
       @app = app
       @cache_store = cache_store
@@ -68,7 +72,7 @@ module Cacheable
     end
 
     def cache
-      @cache_store ||= Rails.cache
+      @cache_store ||= self.class.default_cache_store || Rails.cache
     end
 
     def ie_ajax_request?(env)

--- a/test/cacheable_test.rb
+++ b/test/cacheable_test.rb
@@ -1,12 +1,11 @@
 require File.dirname(__FILE__) + "/test_helper"
 
 class CacheableTest < MiniTest::Unit::TestCase
-  def setup
-    @data = {:foo => 'bar', :bar => [1,['a','b'], 2, {:baz => 'buzz'}], 'qux' => {:red => ['blue', 'green'], :day => true, :night => nil, :updated_at => Time.at(1309362467).utc, :published_on => Time.at(1309320000).utc.to_date}, :format => Mime::Type.lookup('text/html')}
-  end
 
   def test_cache_key_for_handles_nested_everything_and_removes_hash_keys_with_nil_values
+    data = {:foo => 'bar', :bar => [1,['a','b'], 2, {:baz => 'buzz'}], 'qux' => {:red => ['blue', 'green'], :day => true, :night => nil, :updated_at => Time.at(1309362467).utc, :published_on => Time.at(1309320000).utc.to_date}, :format => Mime::Type.lookup('text/html')}
     expected = %|{:foo=>\"bar\", :bar=>[1, [\"a\", \"b\"], 2, {:baz=>\"buzz\"}], \"qux\"=>{:red=>[\"blue\", \"green\"], :day=>true, :night=>nil, :updated_at=>2011-06-29 15:47:47 UTC, :published_on=>Wed, 29 Jun 2011}, :format=>text/html}|
-    assert_equal expected, Cacheable.cache_key_for(@data)
+    assert_equal expected, Cacheable.cache_key_for(data)
   end
+
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require 'mocha'
 module Rails
   class Railtie  
     def self.initializer(*) ; end
+    def self.cache; end
   end
 end
 


### PR DESCRIPTION
We need to split our cacheable machines from the general rails cache, this makes it easier to not have to mokey patch in
the initializers
