### PR TITLE
dont insert middleware after BestStandardsSupport

### DIFF
--- a/lib/cacheable/railtie.rb
+++ b/lib/cacheable/railtie.rb
@@ -2,8 +2,7 @@ module Cacheable
 
   class Railtie < ::Rails::Railtie
     initializer "cachable.configure_active_record" do |config|
-      config.middleware.insert_after 'ActionDispatch::BestStandardsSupport', Cacheable::Middleware
-
+      config.middleware.insert_before 'FixBadAcceptHeader', Cacheable::Middleware
       ActionController::Base.send(:include, Cacheable::Controller)
 
       ActiveRecord::Base.class_eval do


### PR DESCRIPTION
### Problem

`ActionDispatch::BestStandardsSupport` doesnt exist anymore on rails4, so this explodes when trying to use it.
### Solution

ActionDispatch::BestStandardsSupport is not a thing anymore on rails4, to keep the same order on rails3 and 4, we can, instead, insert it before FixBadAcceptHeader.

@camilo @csfrancis for review.
