### PR TITLE
Add support to serve unversioned cacheable entries

### DIFF
--- a/lib/cacheable/controller.rb
+++ b/lib/cacheable/controller.rb
@@ -18,6 +18,10 @@ module Cacheable
       params[:fill_cache] == "true"
     end
 
+    def serve_unversioned_cacheable_entry?
+      false
+    end
+
     # If you're okay with serving pages that are not at the newest version, bump this up
     # to whatever number of seconds you're comfortable with.
     def cache_age_tolerance_in_seconds

--- a/lib/cacheable/response_cache_handler.rb
+++ b/lib/cacheable/response_cache_handler.rb
@@ -7,6 +7,7 @@ module Cacheable
       @controller = controller
       @env = controller.request.env
       @cache_age_tolerance = controller.cache_age_tolerance_in_seconds
+      @serve_unversioned = controller.serve_unversioned_cacheable_entry?
 
       yield self if block_given?
     end
@@ -73,7 +74,11 @@ module Cacheable
       serve_from_browser_cache(versioned_key_hash)
 
       # Memcached
-      serve_from_cache(versioned_key_hash)
+      if @serve_unversioned
+        serve_from_cache(unversioned_key_hash, nil, "Cache hit: server (unversioned)")
+      else
+        serve_from_cache(versioned_key_hash)
+      end
 
       # execute if we can get the lock
       execute

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -107,6 +107,16 @@ class ResponseCacheHandlerTest < MiniTest::Unit::TestCase
     assert_equal 'some text', controller.response.body
   end
 
+  def test_serve_unversioned_cacheable_entry
+    controller.request.env['gzip'] = false
+    assert @controller.respond_to?(:serve_unversioned_cacheable_entry?)
+    @controller.expects(:serve_unversioned_cacheable_entry?).returns(true)
+    @cache_store.expects(:read).with(handler.unversioned_key_hash).returns(page_serialized)
+    expect_page_rendered(page_uncompressed)
+    handler.run!
+    assert_env(false, 'server')
+  end
+
   def test_double_render_still_renders
     @controller.stubs(:serve_from_browser_cache)
     @controller.stubs(:serve_from_cache)


### PR DESCRIPTION
@camilo, @jduff /cc: @dylanahsmith 

As discussed, this adds the ability to have a Controller explicitly serve an unversioned cache entry.
