### PR TITLE
Allow fine grained cache reads and writes

### DIFF
--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -21,6 +21,14 @@ module ResponseBank
       yield
     end
 
+    def write_to_backing_cache_store(_env, key, payload, raw:)
+      cache_store.write(key, payload, raw: raw)
+    end
+
+    def read_from_backing_cache_store(_env, cache_key, cache_store: cache_store)
+      cache_store.read(cache_key)
+    end
+
     def compress(content)
       io = StringIO.new
       gz = Zlib::GzipWriter.new(io)

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -44,10 +44,10 @@ module ResponseBank
 
           ResponseBank.write_to_cache(env['cacheable.key']) do
             payload = MessagePack.dump(cache_data)
-            ResponseBank.cache_store.write(env['cacheable.key'], payload, raw: true)
+            ResponseBank.write_to_backing_cache_store(env, env['cacheable.key'], payload, raw: true)
 
             if env['cacheable.unversioned-key']
-              ResponseBank.cache_store.write(env['cacheable.unversioned-key'], payload, raw: true)
+              ResponseBank.write_to_backing_cache_store(env, env['cacheable.unversioned-key'], payload, raw: true)
             end
           end
 

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -127,7 +127,7 @@ module ResponseBank
     end
 
     def serve_from_cache(cache_key_hash, message, cache_age_tolerance = nil)
-      raw = @cache_store.read(cache_key_hash)
+      raw = ResponseBank.read_from_backing_cache_store(@env, cache_key_hash, cache_store: @cache_store)
 
       if raw
         hit = MessagePack.load(raw)


### PR DESCRIPTION
We are experimenting with various iterations of the cache store that backs our page caching, and would like to allow for finer grained control over the actual reads and writes to our backing caching store on a per-request basis.

This is a small refactor that will allow us to do this in a consistent way.