### PR TITLE
Fix variable shadowing

### DIFF
--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -25,8 +25,8 @@ module ResponseBank
       cache_store.write(key, payload, raw: raw)
     end
 
-    def read_from_backing_cache_store(_env, cache_key, cache_store: cache_store)
-      cache_store.read(cache_key)
+    def read_from_backing_cache_store(_env, cache_key, backing_cache_store: cache_store)
+      backing_cache_store.read(cache_key)
     end
 
     def compress(content)

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -127,7 +127,7 @@ module ResponseBank
     end
 
     def serve_from_cache(cache_key_hash, message, cache_age_tolerance = nil)
-      raw = ResponseBank.read_from_backing_cache_store(@env, cache_key_hash, cache_store: @cache_store)
+      raw = ResponseBank.read_from_backing_cache_store(@env, cache_key_hash, backing_cache_store: @cache_store)
 
       if raw
         hit = MessagePack.load(raw)


### PR DESCRIPTION
When shipping https://github.com/Shopify/response_bank/pull/43, I was shadowing a class variable in `read_from_backing_cache_store` for consistency with the matching `write_to_backing_cache_store` method, which resulted in some code style violations in other projects.

`read_from_backing_cache_store` allows passing in a `cache_store` instance variable passed through some other code paths, which ultimately is always the same as the `ResponseBank.cache_store`. Most of the test suite relies on this, but in production these are always the same variable.

Either way, this is a non-functional change, just not shadowing that variable anymore.