### PR TITLE
Add env option for using a shorter duration on versioned cache

### DIFF
--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -21,8 +21,8 @@ module ResponseBank
       yield
     end
 
-    def write_to_backing_cache_store(_env, key, payload, raw:)
-      cache_store.write(key, payload, raw: raw)
+    def write_to_backing_cache_store(_env, key, payload, raw:, expires_in: nil)
+      cache_store.write(key, payload, raw: raw, expires_in: expires_in)
     end
 
     def read_from_backing_cache_store(_env, cache_key, backing_cache_store: cache_store)

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -44,7 +44,13 @@ module ResponseBank
 
           ResponseBank.write_to_cache(env['cacheable.key']) do
             payload = MessagePack.dump(cache_data)
-            ResponseBank.write_to_backing_cache_store(env, env['cacheable.key'], payload, raw: true)
+            ResponseBank.write_to_backing_cache_store(
+              env,
+              env['cacheable.key'],
+              payload,
+              raw: true,
+              expires_in: env['cacheable.versioned-cache-expiry'],
+            )
 
             if env['cacheable.unversioned-key']
               ResponseBank.write_to_backing_cache_store(env, env['cacheable.unversioned-key'], payload, raw: true)


### PR DESCRIPTION
Part of https://github.com/Shopify/kernel-merch/issues/117

This adds an option in the env which will shorten the cache expiry for the versioned cache. It has no effect on the unversioned cache as that should live longer to prevent thundering herd. `expires_in` is defined as a parameter that cache stores should accept (even if they ignore it) so this should be safe to add to the call.