### PR TITLE
Fix readme example for customizing cache TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ end
 ```ruby
 module ResponseBank
   CACHE_TTL = 30.minutes
-  def write_to_backing_cache_store(_env, key, payload, expires_in: CACHE_TTL)
-    cache_store.write(key, payload, raw: true, expires_in: expires_in)
+  def write_to_backing_cache_store(_env, key, payload, expires_in: nil)
+    cache_store.write(key, payload, raw: true, expires_in: expires_in || CACHE_TTL)
   end
 end
 ```


### PR DESCRIPTION
I was trying to set up `response_bank` with a custom cache TTL using the readme instructions, but the cache was not being expired at all. I realized it was because the readme example had a bug due to improper handling of when `expires_in: nil` was passed in - the `nil` would override the `CACHE_TTL` that is actually supposed to be used as the value passed in to `cache_store#write`:

![image](https://user-images.githubusercontent.com/29219382/172201759-778c1178-9dda-462a-a730-f2daa221f038.png)
(in Ruby 3.1.2)

In the current code, we always pass in the `expires_in` parameter when writing to the cache (`env['cacheable.versioned-cache-expiry']` was added in #46 to offer an option to override cache expiry): https://github.com/Shopify/response_bank/blob/eee105b439a6b9a9bbb4f89f91a38a12300527eb/lib/response_bank/middleware.rb#L51