### PR TITLE
Update rails-html-sanitizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
-    loofah (2.11.0)
+    loofah (2.18.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -86,7 +86,7 @@ GEM
     mocha (1.13.0)
     msgpack (1.4.2)
     nio4r (2.5.8)
-    nokogiri (1.13.4)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.20.1)
@@ -114,7 +114,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.3.0)
+    rails-html-sanitizer (1.4.3)
       loofah (~> 2.3)
     railties (6.0.4)
       actionpack (= 6.0.4)
@@ -165,4 +165,4 @@ DEPENDENCIES
   tzinfo-data (>= 1.2019.3)
 
 BUNDLED WITH
-   2.2.25
+   2.2.32


### PR DESCRIPTION
PR #58 tried to use dependabot to upgrade rails-html-sanitizer but
in that PR ended up downgrading nokogiri and mini_portile2.