### PR TITLE
Support br encoding/decoding in response bank

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     response_bank (1.2.0)
+      brotli
       msgpack
 
 GEM
@@ -73,7 +74,9 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     ast (2.4.2)
+    brotli (0.4.0)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -116,6 +119,9 @@ GEM
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.6.2)
     rack (2.2.6.4)
     rack-test (2.1.0)
@@ -186,6 +192,7 @@ PLATFORMS
 DEPENDENCIES
   minitest (>= 5.18.0)
   mocha
+  pry
   rails (~> 7.0.4)
   rake
   response_bank!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    response_bank (1.2.0)
+    response_bank (1.3.0)
       brotli
       msgpack
 

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -30,7 +30,7 @@ module ResponseBank
       backing_cache_store.read(cache_key, raw: true)
     end
 
-    def compress(content, encoding = 'br')
+    def compress(content, encoding = "gzip")
       case encoding
       when 'gzip'
         Zlib.gzip(content, level: Zlib::BEST_COMPRESSION)
@@ -41,7 +41,7 @@ module ResponseBank
       end
     end
 
-    def decompress(content, encoding = 'br')
+    def decompress(content, encoding = "gzip")
       case encoding
       when 'gzip'
         Zlib.gunzip(content)

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -33,9 +33,9 @@ module ResponseBank
     def compress(content, encoding = 'br')
       case encoding
       when 'gzip'
-        Zlib.gzip(content)
+        Zlib.gzip(content, level: Zlib::BEST_COMPRESSION)
       when 'br'
-        Brotli.deflate(content)
+        Brotli.deflate(content, mode: :text, quality: 7)
       else
         raise ArgumentError, "Unsupported encoding: #{encoding}"
       end
@@ -62,6 +62,9 @@ module ResponseBank
         key = %{#{data[:key_schema_version]}:#{key}} if data[:key_schema_version]
 
         key = %{#{key}:#{hash_value_str(data[:version])}} if data[:version]
+
+        # add the encoding to only the cache key but don't expose this detail in the entity_tag
+        key = %{#{key}:#{hash_value_str(data[:encoding])}} if data[:encoding] && data[:encoding] != "gzip"
 
         key
       when Array

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -55,7 +55,12 @@ module ResponseBank
     private
 
     def hash(key)
-      "cacheable:#{Digest::MD5.hexdigest(key)}"
+      encoding = @env['response_bank.server_cache_encoding']
+      if encoding == 'gzip' || encoding.to_s == ""
+        "cacheable:#{Digest::MD5.hexdigest(key)}"
+      else
+        "cacheable:#{encoding}:#{Digest::MD5.hexdigest(key)}"
+      end
     end
 
     def entity_tag
@@ -143,16 +148,17 @@ module ResponseBank
         # version check
         # unversioned but tolerance threshold
         # regen
-        @headers = @headers.merge(headers)
+        @headers.merge!(headers)
 
-        if @env["gzip"]
-          @headers['Content-Encoding'] = "gzip"
-        else
-          # we have to uncompress because the client doesn't support gzip
-          ResponseBank.log("uncompressing for client without gzip")
-          body = ResponseBank.decompress(body)
+        # if a cache key hit and client doesn't match encoding, return the raw body
+        if !@env['HTTP_ACCEPT_ENCODING'].to_s.include?(@headers['Content-Encoding'])
+          ResponseBank.log("uncompressing payload for client as client doesn't require encoding")
+          body = ResponseBank.decompress(body, @headers['Content-Encoding'])
+          @headers.delete('Content-Encoding')
         end
+
         [status, @headers, [body]]
+
       end
     end
 

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -55,12 +55,7 @@ module ResponseBank
     private
 
     def hash(key)
-      encoding = @env['response_bank.server_cache_encoding']
-      if encoding == 'gzip' || encoding.to_s == ""
-        "cacheable:#{Digest::MD5.hexdigest(key)}"
-      else
-        "cacheable:#{encoding}:#{Digest::MD5.hexdigest(key)}"
-      end
+      "cacheable:" + Digest::MD5.hexdigest(key)
     end
 
     def entity_tag
@@ -68,7 +63,9 @@ module ResponseBank
     end
 
     def cache_key
-      @cache_key ||= ResponseBank.cache_key_for(key: @key_data, key_schema_version: @key_schema_version)
+      # add the encoding to only the cache key but don't expose this detail in the entity_tag
+      # TODO: consider moving this to the cache_key_for method
+      @cache_key ||= ResponseBank.cache_key_for(key: @key_data, key_schema_version: @key_schema_version) + @env['response_bank.server_cache_encoding']
     end
 
     def cacheable_info_dump

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -63,9 +63,7 @@ module ResponseBank
     end
 
     def cache_key
-      # add the encoding to only the cache key but don't expose this detail in the entity_tag
-      # TODO: consider moving this to the cache_key_for method
-      @cache_key ||= ResponseBank.cache_key_for(key: @key_data, key_schema_version: @key_schema_version) + @env['response_bank.server_cache_encoding']
+      @cache_key ||= ResponseBank.cache_key_for(key: @key_data, key_schema_version: @key_schema_version, encoding: @env['response_bank.server_cache_encoding'])
     end
 
     def cacheable_info_dump

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ResponseBank
-  VERSION = "1.2.2"
+  VERSION = "1.3.0"
 end

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -20,9 +20,11 @@ Gem::Specification.new do |s|
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 
   s.add_runtime_dependency("msgpack")
+  s.add_runtime_dependency("brotli")
 
   s.add_development_dependency("minitest", ">= 5.18.0")
   s.add_development_dependency("mocha", ">= 2.0.0")
   s.add_development_dependency("rake")
   s.add_development_dependency("rails", ">= 6.1")
+  s.add_development_dependency("pry")
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -55,7 +55,7 @@ class ResponseBankControllerTest < Minitest::Test
   end
 
   def test_server_cache_hit
-    controller.request.env['gzip'] = false
+    controller.request.env['response_bank.server_cache_encoding'] = 'br'
     @cache_store.expects(:read).returns(page_serialized)
     ResponseBank::ResponseCacheHandler.any_instance.expects(:entity_tag_hash).returns('*').at_least_once
     controller.expects(:render).with(plain: '<body>hi.</body>', status: 200)
@@ -78,6 +78,6 @@ class ResponseBankControllerTest < Minitest::Test
   end
 
   def page_serialized
-    MessagePack.dump([200, {"Content-Type" => "text/html"}, ResponseBank.compress("<body>hi.</body>"), 1331765506])
+    MessagePack.dump([200, {"Content-Type" => "text/html", "Content-Encoding" => "br"}, ResponseBank.compress("<body>hi.</body>", "br"), 1331765506])
   end
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -64,6 +64,7 @@ class ResponseBankControllerTest < Minitest::Test
   end
 
   def test_client_cache_hit
+    controller.request.env['response_bank.server_cache_encoding'] = 'br'
     controller.request.env['HTTP_IF_NONE_MATCH'] = 'deadbeef'
     ResponseBank::ResponseCacheHandler.any_instance.expects(:entity_tag_hash).returns('deadbeef').at_least_once
     controller.expects(:head).with(:not_modified)


### PR DESCRIPTION
# Description

This pull request changes the default encoding in Shopify page cache to use brotli, as it outperforms zlib (gzip) in compression ratio, compression time, decompression time, and memory usage. A comparison between the two encodings can be found [here](https://github.com/Shopify/caching-platform/pull/228/files#diff-bcdf9c5b773d4c56e00e2ac3df99b659dbf39b833804ed221308b99cc0a9ef54). Additionally, end-to-end [testing](https://github.com/Shopify/caching-platform/pull/273/files#diff-601c826f5d4ff214b83a4b93ae28627af50a9087df511d9d07cd9916423ff688) of various brotli-encoded websites has shown that it outperforms zlib in compression ratio and decompression time.

This change is completely *backward compatible*, and existing page caches will remain for one hour before being evicted. During the cut-over, the cache hit rate may temporarily decrease as all page caches need to be refilled. Cloudflare only supports one encoding type (gzip today, and we will make it brotli), so if a client requests an encoding other than brotli, SFR will respond with plain text.

* Related to issue: https://github.com/Shopify/caching-platform/issues/227

# Test

Tested using spin test shop in SFR, and ModHeader chrome plugin (spin test shop does not have CF between browser and server, so we can manually control the `Accept-Encoding` header sent from Chrome). We tested 6 scenarios.

<details>

<summary>click me for details</summary>

## Scenario 1: server cache miss, client cache miss, `Accept-Encoding: gzip`

Run `echo FLUSHALL | redis-cli -h localhost -p 12091` command in spin to clean up server cache, clean up the browser cache, in ModHeader plugin, set up a rule for `Accept-Encoding: gzip` in request header.

Run `bundle install && dev debug` in spin to start the server, and open `https://shop1.shopify.sfr.jason-chen.us.spin.dev/` in Chrome:

<img width="1692" alt="image" src="https://user-images.githubusercontent.com/3954499/226994221-273b1577-3cbf-4e7e-aafd-49c182449bef.png">

Successfully opened the page with `200` HTTP code, we saw `x-cache: miss` in the response which means server cache miss for `gzip` encoding.

## Scenario 2: client cache hit, `Accept-Encoding: gzip`

Refresh the link, the page responsed with `304` which means the client cache hit: 
<img width="1699" alt="image" src="https://user-images.githubusercontent.com/3954499/226994860-bf0f1aba-214d-4f50-a544-cae6f3bce4c5.png">

In the response header, we saw `x-cache: hit, client` which also indicates, it's client cache hit.

## Scenario 3: server cache hit, client cache miss, `Accept-Encoding: gzip`

Clear the Chrome cache, and refresh the page

<img width="1692" alt="image" src="https://user-images.githubusercontent.com/3954499/226995332-8a5dcb78-2de0-4c93-84c1-c5bf0bbae224.png">

HTTP code `200` with `x-cache: hit, server` which means server cache hit.

## Scenario 4: server cache miss, client cache miss, `Accept-Encoding: br`

Clear browser and server cache, in ModHeader, set up a rule `Accept-Encoding: br` in request header. Open the test shop in chrome:

<img width="1697" alt="image" src="https://user-images.githubusercontent.com/3954499/226996118-0c4d4856-f3d4-4075-bfad-fcffede1f45b.png">

Successfully opened the page with `200` HTTP code, we saw `x-cache: miss` in the response which means server cache miss for `br` encoding.

## Scenario 5: client cache hit, `Accept-Encoding: br`

Refresh the page, and we received a `304` http code: 
<img width="1695" alt="image" src="https://user-images.githubusercontent.com/3954499/226996346-705f3f97-96db-43cf-8475-f1d77db5698f.png">

HTTP code `304` indicates it's client cache hit. The response has `x-cache: hit, client` which also indicates it's a client cache hit.

## Scenario 6: server cache hit, client cache miss, `Accept-Encoding: gzip`

Clear the Chrome cache, and refresh the page

<img width="1702" alt="image" src="https://user-images.githubusercontent.com/3954499/226996622-c2fba0c8-6563-4191-8fd2-cc7aff93fa6e.png">

HTTP code `200` with `x-cache: hit, server` which means server cache hit.

</details>