### PR TITLE
Relaxed 304 If-None-Match test to support weak key

### DIFF
--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -113,7 +113,12 @@ module ResponseBank
     end
 
     def serve_from_browser_cache(cache_key_hash)
-      if @env["HTTP_IF_NONE_MATCH"] == cache_key_hash
+      # Support for Etag variations including:
+      # If-None-Match: abc
+      # If-None-Match: "abc"
+      # If-None-Match: W/"abc"
+      # If-None-Match: "abc", "def"
+      if !@env["HTTP_IF_NONE_MATCH"].nil? && @env["HTTP_IF_NONE_MATCH"].include?(cache_key_hash)
         @env['cacheable.miss']  = false
         @env['cacheable.store'] = 'client'
 

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -74,6 +74,18 @@ class ResponseCacheHandlerTest < Minitest::Test
     assert_env(false, 'client')
   end
 
+  def test_client_cache_hit_quoted
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "\"#{handler.versioned_key_hash}\""
+    handler.run!
+    assert_env(false, 'client')
+  end
+
+  def test_client_cache_hit_weak
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "W/\"#{handler.versioned_key_hash}\""
+    handler.run!
+    assert_env(false, 'client')
+  end
+
   def test_server_cache_hit
     controller.request.env['gzip'] = false
     @cache_store.expects(:read).with(handler.versioned_key_hash, raw: true).returns(page_serialized)


### PR DESCRIPTION
HTTP Requests with [If-None-Match](https://httpwg.org/specs/rfc9110.html#field.if-none-match) should support quoted, weak and arrays of entity tags. This PR enables a more generous match for eTags to increase 304 responses.

Specifically, given an `etag: abc123` value, the following `if-none-match` requests should yield a 304:

* `if-none-match: abc123`
* `if-none-match: "abc123"`
* `if-none-match: W/"abc123"`
* `if-none-match: "abc123", "def456"`
