### PR TITLE
Parse Etags to match them.

### DIFF
--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -80,10 +80,22 @@ class ResponseCacheHandlerTest < Minitest::Test
     assert_env(false, 'client')
   end
 
+  def test_client_cache_hit_multi
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "foo, \"#{handler.versioned_key_hash}\", bar"
+    handler.run!
+    assert_env(false, 'client')
+  end
+
   def test_client_cache_hit_weak
     controller.request.env['HTTP_IF_NONE_MATCH'] = "W/\"#{handler.versioned_key_hash}\""
     handler.run!
     assert_env(false, 'client')
+  end
+
+  def test_client_cache_miss_partial
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "aaa#{handler.versioned_key_hash}zzz"
+    handler.run!
+    assert_env(true, nil)
   end
 
   def test_server_cache_hit


### PR DESCRIPTION
Followup: https://github.com/Shopify/response_bank/pull/64

`String#include?` isn't precise enough as it could match only one part of an ETag.

Granted the vast majority of tags are always the same size, so the risk is minimal, but it doesn't cost much to be correct.