### PR TITLE
Collapse cache entry to single key

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,6 @@ inherit_from:
   - https://shopify.github.io/ruby-style-guide/rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.7
   Exclude:
     - vendor/bundle/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rails', '~> 7.0.4'
-gem 'rubocop', '1.48.0', require: false
+gem 'rubocop', require: false, group: :test
+gem 'mocha', require: false, group: :test
 gem 'simplecov', require: false, group: :test
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    response_bank (1.1.0)
+    response_bank (1.2.0)
       msgpack
       useragent
 
@@ -151,7 +151,7 @@ GEM
     rake (13.0.6)
     regexp_parser (2.7.0)
     rexml (3.2.5)
-    rubocop (1.48.0)
+    rubocop (1.48.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
@@ -175,8 +175,6 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2023.2)
-      tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
     useragent (0.16.10)
     websocket-driver (0.7.5)
@@ -188,14 +186,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (>= 5.13.0)
-  mocha (>= 1.10.0)
+  minitest (>= 5.18.0)
+  mocha
   rails (~> 7.0.4)
   rake
   response_bank!
-  rubocop (= 1.48.0)
+  rubocop
   simplecov
-  tzinfo-data (>= 1.2019.3)
 
 BUNDLED WITH
    2.3.11

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -49,11 +49,11 @@ module ResponseBank
 
         key = hash_value_str(data[:key])
 
-        return key unless data.key?(:version)
+        key = %{#{data[:key_schema_version]}:#{key}} unless data[:key_schema_version].blank?
 
-        version = hash_value_str(data[:version])
+        key = %{#{key}:#{hash_value_str(data[:version])}} unless data[:version].blank?
 
-        [key, version].join(":")
+        key
       when Array
         data.inspect
       when Time, DateTime

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -49,9 +49,9 @@ module ResponseBank
 
         key = hash_value_str(data[:key])
 
-        key = %{#{data[:key_schema_version]}:#{key}} unless data[:key_schema_version].blank?
+        key = %{#{data[:key_schema_version]}:#{key}} if data[:key_schema_version]
 
-        key = %{#{key}:#{hash_value_str(data[:version])}} unless data[:version].blank?
+        key = %{#{key}:#{hash_value_str(data[:version])}} if data[:version]
 
         key
       when Array

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -29,8 +29,8 @@ module ResponseBank
 
     def run!
       @env['cacheable.cache']           = true
-      @env['cacheable.key']             = versioned_key_hash
-      @env['cacheable.unversioned-key'] = unversioned_key_hash
+      @env['cacheable.key']             = entity_tag_hash
+      @env['cacheable.unversioned-key'] = cache_key_hash
 
       ResponseBank.log(cacheable_info_dump)
 
@@ -41,32 +41,32 @@ module ResponseBank
       end
     end
 
-    def versioned_key_hash
-      @versioned_key_hash ||= key_hash(versioned_key)
+    def entity_tag_hash
+      @entity_tag_hash ||= hash(entity_tag)
     end
 
-    def unversioned_key_hash
-      @unversioned_key_hash ||= key_hash(unversioned_key)
+    def cache_key_hash
+      @cache_key_hash ||= hash(cache_key)
     end
 
     private
 
-    def key_hash(key)
+    def hash(key)
       "cacheable:#{Digest::MD5.hexdigest(key)}"
     end
 
-    def versioned_key
-      @versioned_key ||= ResponseBank.cache_key_for(key: @key_data, version: @version_data)
+    def entity_tag
+      @entity_tag ||= ResponseBank.cache_key_for(key: @key_data, version: @version_data)
     end
 
-    def unversioned_key
-      @unversioned_key ||= ResponseBank.cache_key_for(key: @key_data)
+    def cache_key
+      @cache_key ||= ResponseBank.cache_key_for(key: @key_data)
     end
 
     def cacheable_info_dump
       log_info = [
-        "Raw cacheable.key: #{versioned_key}",
-        "cacheable.key: #{versioned_key_hash}",
+        "Raw cacheable.key: #{entity_tag}",
+        "cacheable.key: #{entity_tag_hash}",
       ]
 
       if @env['HTTP_IF_NONE_MATCH']
@@ -78,68 +78,32 @@ module ResponseBank
 
     def try_to_serve_from_cache
       # Etag
-      response = serve_from_browser_cache(versioned_key_hash)
-
+      response = serve_from_browser_cache(entity_tag_hash, @env['HTTP_IF_NONE_MATCH'])
       return response if response
 
-      # Memcached
-      response = if @serve_unversioned
-        serve_from_cache(unversioned_key_hash, "Cache hit: server (unversioned)")
-      else
-        serve_from_cache(versioned_key_hash, "Cache hit: server")
-      end
-
+      response = serve_from_cache(cache_key_hash, entity_tag_hash, @cache_age_tolerance)
       return response if response
-
-      @env['cacheable.locked'] ||= false
-
-      if @env['cacheable.locked'] || ResponseBank.acquire_lock(versioned_key_hash)
-        # execute if we can get the lock
-        @env['cacheable.locked'] = true
-      elsif serving_from_noncurrent_but_recent_version_acceptable?
-        # serve a stale version
-        response = serve_from_cache(unversioned_key_hash, "Cache hit: server (recent)", @cache_age_tolerance)
-
-        return response if response
-      end
 
       # No cache hit; this request cannot be handled from cache.
       # Yield to the controller and mark for writing into cache.
       refill_cache
     end
 
-    def serving_from_noncurrent_but_recent_version_acceptable?
-      @cache_age_tolerance > 0
-    end
+    def serve_from_browser_cache(entity_tag, if_none_match)
+      if etag_matches?(entity_tag, if_none_match)
+        @env['cacheable.miss']  = false
+        @env['cacheable.store'] = 'client'
 
-    def serve_from_browser_cache(cache_key_hash)
-      # Support for Etag variations including:
-      # If-None-Match: abc
-      # If-None-Match: "abc"
-      # If-None-Match: W/"abc"
-      # If-None-Match: "abc", "def"
-      if (if_none_match = @env["HTTP_IF_NONE_MATCH"])
-        etags = if_none_match.split(",")
-        etags.each do |tag|
-          tag.sub!(/\"?\s*\z/, "")
-          tag.sub!(/\A\s*(W\/)?\"?/, "")
-        end
+        @headers.delete('Content-Type')
+        @headers.delete('Content-Length')
 
-        if etags.include?(cache_key_hash)
-          @env['cacheable.miss']  = false
-          @env['cacheable.store'] = 'client'
+        ResponseBank.log("Cache hit: client")
 
-          @headers.delete('Content-Type')
-          @headers.delete('Content-Length')
-
-          ResponseBank.log("Cache hit: client")
-
-          [304, @headers, []]
-        end
+        [304, @headers, []]
       end
     end
 
-    def serve_from_cache(cache_key_hash, message, cache_age_tolerance = nil)
+    def serve_from_cache(cache_key_hash, match_entity_tag = "*", cache_age_tolerance = nil)
       raw = ResponseBank.read_from_backing_cache_store(@env, cache_key_hash, backing_cache_store: @cache_store)
 
       if raw
@@ -148,37 +112,77 @@ module ResponseBank
         @env['cacheable.miss']  = false
         @env['cacheable.store'] = 'server'
 
-        status, content_type, body, timestamp, location = hit
+        status, headers, body, timestamp, location = hit
 
-        if cache_age_tolerance && page_too_old?(timestamp, cache_age_tolerance)
-          ResponseBank.log("Found an unversioned cache entry, but it was too old (#{timestamp})")
+        # polyfill headers for legacy versions
+        headers = { 'Content-Type' => headers.to_s } if headers.is_a? String
+        headers['Location'] = location if location
 
-          nil
+        @env['cacheable.locked'] ||= false
+
+        # to preserve the unversioned/versioned logging messages from past releases we split the match_entity_tag test
+        if match_entity_tag == "*"
+          ResponseBank.log("Cache hit: server (unversioned)")
+          # page tolerance only applies for versioned + etag mismatch
+        elsif etag_matches?(headers['ETag'], match_entity_tag)
+          ResponseBank.log("Cache hit: server")
         else
-          @headers['Content-Type'] = content_type
-
-          @headers['Location'] = location if location
-
-          if @env["gzip"]
-            @headers['Content-Encoding'] = "gzip"
+          # cache miss; check to see if any parallel requests already are regenerating the cache
+          if ResponseBank.acquire_lock(match_entity_tag)
+            # execute if we can get the lock
+            @env['cacheable.locked'] = true
+            return nil
+          elsif stale_while_revalidate?(timestamp, cache_age_tolerance)
+            # cache is being regenerated, can we avoid piling on and use a stale version in the interim?
+            ResponseBank.log("Cache hit: server (recent)")
           else
-            # we have to uncompress because the client doesn't support gzip
-            ResponseBank.log("uncompressing for client without gzip")
-            body = ResponseBank.decompress(body)
+            ResponseBank.log("Found an unversioned cache entry, but it was too old (#{timestamp})")
+            return nil
           end
-
-          ResponseBank.log(message)
-
-          [status, @headers, [body]]
         end
+
+        # version check
+        # unversioned but tolerance threshold
+        # regen
+        @headers = @headers.merge(headers)
+
+        if @env["gzip"]
+          @headers['Content-Encoding'] = "gzip"
+        else
+          # we have to uncompress because the client doesn't support gzip
+          ResponseBank.log("uncompressing for client without gzip")
+          body = ResponseBank.decompress(body)
+        end
+        [status, @headers, [body]]
       end
     end
 
-    def page_too_old?(timestamp, cache_age_tolerance)
-      !timestamp || timestamp < (Time.now.to_i - cache_age_tolerance)
+    def etag_matches?(entity_tag, if_none_match)
+      # Support for Etag variations including:
+      # If-None-Match: abc
+      # If-None-Match: "abc"
+      # If-None-Match: W/"abc"
+      # If-None-Match: "abc", "def"
+      # If-None-Match: "*"
+      return false unless entity_tag
+      return false unless if_none_match
+
+      # strictly speaking an unquoted etag is not valid, yet common
+      # to avoid unintended greedy matches in we check for naked entity then includes with quoted entity values
+      if_none_match == "*" || if_none_match == entity_tag || if_none_match.include?(%{"#{entity_tag}"})
+    end
+
+    def stale_while_revalidate?(timestamp, cache_age_tolerance)
+      return false if !cache_age_tolerance
+      return false if !timestamp
+
+      timestamp >= (Time.now.to_i - cache_age_tolerance)
     end
 
     def refill_cache
+      # non cache hits do not yet have the lock
+      ResponseBank.acquire_lock(entity_tag_hash) unless @env['cacheable.locked']
+      @env['cacheable.locked'] = true
       @env['cacheable.miss'] = true
 
       ResponseBank.log("Refilling cache")

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -131,13 +131,13 @@ module ResponseBank
           if ResponseBank.acquire_lock(match_entity_tag)
             # execute if we can get the lock
             @env['cacheable.locked'] = true
-            return nil
+            return
           elsif stale_while_revalidate?(timestamp, cache_age_tolerance)
             # cache is being regenerated, can we avoid piling on and use a stale version in the interim?
             ResponseBank.log("Cache hit: server (recent)")
           else
             ResponseBank.log("Found an unversioned cache entry, but it was too old (#{timestamp})")
-            return nil
+            return
           end
         end
 

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ResponseBank
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -15,16 +15,15 @@ Gem::Specification.new do |s|
   s.files         = Dir["lib/**/*.rb", "README.md", "LICENSE.txt"]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.4.0"
+  s.required_ruby_version = ">= 2.7.0"
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 
   s.add_runtime_dependency("useragent")
   s.add_runtime_dependency("msgpack")
 
-  s.add_development_dependency("minitest", ">= 5.13.0")
-  s.add_development_dependency("mocha", ">= 1.10.0")
+  s.add_development_dependency("minitest", ">= 5.18.0")
+  s.add_development_dependency("mocha", ">= 2.0.0")
   s.add_development_dependency("rake")
-  s.add_development_dependency("rails", ">= 5.0")
-  s.add_development_dependency("tzinfo-data", ">= 1.2019.3")
+  s.add_development_dependency("rails", ">= 6.1")
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -57,6 +57,7 @@ class ResponseBankControllerTest < Minitest::Test
   def test_server_cache_hit
     controller.request.env['gzip'] = false
     @cache_store.expects(:read).returns(page_serialized)
+    ResponseBank::ResponseCacheHandler.any_instance.expects(:entity_tag_hash).returns('*').at_least_once
     controller.expects(:render).with(plain: '<body>hi.</body>', status: 200)
 
     controller.send(:response_cache) {}
@@ -64,7 +65,7 @@ class ResponseBankControllerTest < Minitest::Test
 
   def test_client_cache_hit
     controller.request.env['HTTP_IF_NONE_MATCH'] = 'deadbeef'
-    ResponseBank::ResponseCacheHandler.any_instance.expects(:versioned_key_hash).returns('deadbeef').at_least_once
+    ResponseBank::ResponseCacheHandler.any_instance.expects(:entity_tag_hash).returns('deadbeef').at_least_once
     controller.expects(:head).with(:not_modified)
 
     controller.send(:response_cache) {}
@@ -77,6 +78,6 @@ class ResponseBankControllerTest < Minitest::Test
   end
 
   def page_serialized
-    MessagePack.dump([200, "text/html", ResponseBank.compress("<body>hi.</body>"), 1331765506])
+    MessagePack.dump([200, {"Content-Type" => "text/html"}, ResponseBank.compress("<body>hi.</body>"), 1331765506])
   end
 end

--- a/test/response_bank_test.rb
+++ b/test/response_bank_test.rb
@@ -33,6 +33,17 @@ class ResponseBankTest < Minitest::Test
     assert_equal(expected, ResponseBank.cache_key_for(key: @data, version: version))
   end
 
+  def test_cache_key_with_version
+    key = "/index.html"
+    version = 42
+    assert_equal('/index.html', ResponseBank.cache_key_for({key: key}))
+    assert_equal('/index.html:42', ResponseBank.cache_key_for({key: key, version: version}))
+    assert_equal('/index.html:42', ResponseBank.cache_key_for({key: key, version: version, key_schema_version: nil}))
+    assert_equal('/index.html:42', ResponseBank.cache_key_for({key: key, version: version, key_schema_version: ""}))
+    assert_equal('1:/index.html:42', ResponseBank.cache_key_for({key: key, version: version, key_schema_version: 1}))
+  end
+
+
   def test_cache_key_for_array
     assert_equal('["foo", "bar", "baz"]', ResponseBank.cache_key_for(%w[foo bar baz]))
   end

--- a/test/response_bank_test.rb
+++ b/test/response_bank_test.rb
@@ -39,7 +39,6 @@ class ResponseBankTest < Minitest::Test
     assert_equal('/index.html', ResponseBank.cache_key_for({key: key}))
     assert_equal('/index.html:42', ResponseBank.cache_key_for({key: key, version: version}))
     assert_equal('/index.html:42', ResponseBank.cache_key_for({key: key, version: version, key_schema_version: nil}))
-    assert_equal('/index.html:42', ResponseBank.cache_key_for({key: key, version: version, key_schema_version: ""}))
     assert_equal('1:/index.html:42', ResponseBank.cache_key_for({key: key, version: version, key_schema_version: 1}))
   end
 

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -6,7 +6,7 @@ ActionController::Base.cache_store = :memory_store
 class ResponseCacheHandlerTest < Minitest::Test
   def setup
     @cache_store = stub.tap { |s| s.stubs(read: nil) }
-    controller.request.env['HTTP_IF_NONE_MATCH'] = 'deadbeefdeadbeef'
+    controller.request.env['HTTP_IF_NONE_MATCH'] = '"should-not-match"'
     ResponseBank.stubs(:acquire_lock).returns(true)
   end
 
@@ -15,7 +15,7 @@ class ResponseCacheHandlerTest < Minitest::Test
   end
 
   def handler
-    @handler = ResponseBank::ResponseCacheHandler.new(
+    @handler ||= ResponseBank::ResponseCacheHandler.new(
       key_data: controller.send(:cache_key_data),
       version_data: controller.send(:cache_version_data),
       cache_store: @cache_store,
@@ -24,20 +24,22 @@ class ResponseCacheHandlerTest < Minitest::Test
       serve_unversioned: controller.send(:serve_unversioned_cacheable_entry?),
       cache_age_tolerance: controller.send(:cache_age_tolerance_in_seconds),
       headers: controller.response.headers,
-      &proc { [200, {}, 'some text'] }
+      &proc { [200, {}, 'dynamic output'] }
     )
   end
 
-  def page
-    [200, "text/html", ResponseBank.compress("<body>hi.</body>"), 1331765506]
+  def page(cache_hit = true)
+    etag = cache_hit ? handler.entity_tag_hash : "not-cached"
+    [200, {"Content-Type" => "text/html", "ETag" => etag}, ResponseBank.compress("<body>cached output</body>"), 1331765506]
   end
 
-  def page_serialized
-    MessagePack.dump(page)
+  def page_cache_entry(cache_hit = true)
+    MessagePack.dump(page(cache_hit))
   end
 
-  def page_uncompressed
-    [200, "text/html", "<body>hi.</body>", 1331765506]
+  def page_uncompressed(cache_hit = true)
+    etag = cache_hit ? handler.entity_tag_hash : "not-cached"
+    [200, {"Content-Type" => "text/html", "ETag" => etag}, "<body>cached output</body>", 1331765506]
   end
 
   def test_cache_miss_block_is_only_called_once_if_it_return_nil
@@ -59,112 +61,125 @@ class ResponseCacheHandlerTest < Minitest::Test
 
     my_handler.run!
     assert_equal(1, called)
-    assert_env(true, nil)
+    assert_cache_miss(true, nil)
   end
 
   def test_cache_miss
     _, _, body = handler.run!
-    assert_equal('some text', body)
-    assert_env(true, nil)
+    assert_equal('dynamic output', body)
+    assert_cache_miss(true, nil)
   end
 
   def test_client_cache_hit
-    controller.request.env['HTTP_IF_NONE_MATCH'] = handler.versioned_key_hash
+    controller.request.env['HTTP_IF_NONE_MATCH'] = handler.entity_tag_hash
     handler.run!
-    assert_env(false, 'client')
+    assert_cache_miss(false, 'client')
   end
 
   def test_client_cache_hit_quoted
-    controller.request.env['HTTP_IF_NONE_MATCH'] = "\"#{handler.versioned_key_hash}\""
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "\"#{handler.entity_tag_hash}\""
     handler.run!
-    assert_env(false, 'client')
+    assert_cache_miss(false, 'client')
   end
 
   def test_client_cache_hit_multi
-    controller.request.env['HTTP_IF_NONE_MATCH'] = "foo, \"#{handler.versioned_key_hash}\", bar"
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "foo, \"#{handler.entity_tag_hash}\", bar"
     handler.run!
-    assert_env(false, 'client')
+    assert_cache_miss(false, 'client')
   end
 
   def test_client_cache_hit_weak
-    controller.request.env['HTTP_IF_NONE_MATCH'] = "W/\"#{handler.versioned_key_hash}\""
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "W/\"#{handler.entity_tag_hash}\""
     handler.run!
-    assert_env(false, 'client')
+    assert_cache_miss(false, 'client')
+  end
+
+  def test_client_cache_hit_wildcard
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "*"
+    handler.run!
+    assert_cache_miss(false, 'client')
   end
 
   def test_client_cache_miss_partial
-    controller.request.env['HTTP_IF_NONE_MATCH'] = "aaa#{handler.versioned_key_hash}zzz"
+    controller.request.env['HTTP_IF_NONE_MATCH'] = "aaa#{handler.entity_tag_hash}zzz"
     handler.run!
-    assert_env(true, nil)
+    assert_cache_miss(true, nil)
   end
 
   def test_server_cache_hit
-    controller.request.env['gzip'] = false
-    @cache_store.expects(:read).with(handler.versioned_key_hash, raw: true).returns(page_serialized)
-    expect_page_rendered(page_uncompressed)
-    handler.run!
-    assert_env(false, 'server')
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry)
+    expect_page_rendered(page_uncompressed, false)
+    assert_cache_miss(false, 'server')
   end
 
   def test_server_cache_hit_support_gzip
-    controller.request.env['gzip'] = true
-    @cache_store.expects(:read).with(handler.versioned_key_hash, raw: true).returns(page_serialized)
-    expect_compressed_page_rendered(page)
-    handler.run!
-    assert_env(false, 'server')
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry)
+    expect_page_rendered(page(true))
+    assert_cache_miss(false, 'server')
   end
 
   def test_server_recent_cache_hit
     @controller.stubs(:cache_age_tolerance_in_seconds).returns(999999999999)
-    @cache_store.expects(:read).with(handler.unversioned_key_hash, raw: true).returns(page_serialized)
-    expect_page_rendered(page_uncompressed)
-    ResponseBank.expects(:acquire_lock).with(handler.versioned_key_hash)
-    handler.run!
-    assert_env(false, 'server')
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry(false))
+    ResponseBank.expects(:acquire_lock).with(handler.entity_tag_hash)
+    expect_page_rendered(page(false))
+
+    assert_cache_miss(false, 'server')
   end
 
   def test_server_recent_cache_acceptable_but_none_found
     @controller.stubs(:cache_age_tolerance_in_seconds).returns(999999999999)
     _, _, body = handler.run!
-    assert_equal('some text', body)
-    assert_env(true, :anything)
+    assert_equal('dynamic output', body)
+    assert_cache_miss(true, :anything)
   end
 
   def test_nil_timestamp_in_second_lookup_causes_a_cache_miss
     ResponseBank.stubs(:acquire_lock).returns(false)
     @controller.stubs(:cache_age_tolerance_in_seconds).returns(999999999999)
-    @cache_store.expects(:read).with(handler.unversioned_key_hash, raw: true).returns(MessagePack.dump(page[0..2]))
+    cache_page = page(false)
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(MessagePack.dump(cache_page[0..2]))
     handler.run!
-    assert_env(true, :anything)
+
+    assert_cache_miss(true, :anything)
   end
+
+  def test_server_recent_cache_miss
+    @controller.stubs(:cache_age_tolerance_in_seconds).returns(999999999999)
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry(false))
+
+    ResponseBank.expects(:acquire_lock).with(handler.entity_tag_hash).returns(true)
+    handler.run!
+
+    assert_cache_miss(true, 'server')
+  end
+
 
   def test_recent_cache_available_but_not_acceptable
     ResponseBank.stubs(:acquire_lock).returns(false)
     @controller.stubs(:cache_age_tolerance_in_seconds).returns(15)
-    @cache_store.expects(:read).with(handler.unversioned_key_hash, raw: true).returns(page_serialized)
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry(false))
     _, _, body = handler.run!
-    assert_equal('some text', body)
-    assert_env(true, :anything)
+    assert_equal('dynamic output', body)
+    assert_cache_miss(true, :anything)
   end
 
   def test_force_refill_cache
     @controller.stubs(force_refill_cache?: true)
-    controller.request.env['HTTP_IF_NONE_MATCH'] = handler.versioned_key_hash
-    @cache_store.stubs(:read).with(handler.versioned_key_hash, raw: true).returns(page_serialized)
+    controller.request.env['HTTP_IF_NONE_MATCH'] = handler.entity_tag_hash
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).never
 
     _, _, body = handler.run!
-    assert_env(true, nil)
-    assert_equal('some text', body)
+    assert_cache_miss(true, nil)
+    assert_equal('dynamic output', body)
   end
 
   def test_serve_unversioned_cacheable_entry
-    controller.request.env['gzip'] = false
     assert(@controller.respond_to?(:serve_unversioned_cacheable_entry?, true))
-    @controller.expects(:serve_unversioned_cacheable_entry?).returns(true).times(4)
-    @cache_store.expects(:read).with(handler.unversioned_key_hash, raw: true).returns(page_serialized)
-    expect_page_rendered(page_uncompressed)
-    handler.run!
-    assert_env(false, 'server')
+    @controller.expects(:serve_unversioned_cacheable_entry?).returns(true).times(1)
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry)
+    expect_page_rendered(page)
+    assert_cache_miss(false, 'server')
   end
 
   def test_double_render_still_renders
@@ -177,11 +192,15 @@ class ResponseCacheHandlerTest < Minitest::Test
     handler.run!
   end
 
-  def assert_env(miss, store)
-    vkh  = handler.versioned_key_hash
-    uvkh = handler.unversioned_key_hash
-    assert_equal(true,  controller.request.env['cacheable.cache'])
-    assert_equal(miss,  controller.request.env['cacheable.miss'])
+  def assert_cache_miss(miss, store)
+    etag  = handler.entity_tag_hash
+    unversioned_cache_key = handler.cache_key_hash
+    assert_equal(true, controller.request.env['cacheable.cache'])
+    assert_equal(miss, controller.request.env['cacheable.miss'])
+
+    if (miss)
+      assert_equal(true, controller.request.env['cacheable.locked'])
+    end
 
     if store.nil?
       assert_nil(controller.request.env['cacheable.store'])
@@ -189,22 +208,23 @@ class ResponseCacheHandlerTest < Minitest::Test
       assert_equal(store, controller.request.env['cacheable.store'])
     end
 
-    assert_equal(vkh,   controller.request.env['cacheable.key'])
-    assert_equal(uvkh,  controller.request.env['cacheable.unversioned-key'])
+    assert_equal(etag, controller.request.env['cacheable.key'])
+    assert_equal(unversioned_cache_key, controller.request.env['cacheable.unversioned-key'])
   end
 
-  def expect_page_rendered(page)
-    _status, content_type, body, _timestamp = page
-    ResponseBank.expects(:decompress).returns(body).once
+  def expect_page_rendered(cache_entry, compressed_body = true)
+    controller.request.env['gzip'] = compressed_body
 
-    @controller.response.headers.expects(:[]=).with('Content-Type', content_type)
-  end
+    _status, _headers, _body, _timestamp = cache_entry
+    ResponseBank.expects(:decompress).never if compressed_body
+    ResponseBank.expects(:decompress).returns(_body).once unless compressed_body
 
-  def expect_compressed_page_rendered(page)
-    _status, content_type, _body, _timestamp = page
-    ResponseBank.expects(:decompress).never
+    status, headers, body = handler.run!
 
-    @controller.response.headers.expects(:[]=).with('Content-Type', content_type)
-    @controller.response.headers.expects(:[]=).with('Content-Encoding', "gzip")
+    assert_equal(status, _status)
+    assert_equal(headers["Content-Type"], _headers['Content-Type'])
+    assert_equal(headers["Content-Encoding"], "gzip") if compressed_body
+
+    body
   end
 end


### PR DESCRIPTION
Previously a cache miss would be cached twice - an unversioned entry + a versioned entry for the same cache key. This would allow cases where the versioned entry was not strictly needed and shouldn't cause a cache miss (eg: bot traffic). However, this doubling of the cache entries reduces the effective memory footprint and requires multiple round trips to the backing cache.

This PR collapses the cache to a single key and uses the entity-tag (`etag`) value for the situations when a strict cache value needs to be evaluated. This reduces the number of queries to the cache while preserving the intended semantics of the cache. 

Additionally, we move the a limited header set into the cache. Header caching is required for response metadata caching and will support other use cases such as the use of `cache-tags` and other `cache-control` header values.

Other changes in this pr:
* refactoring the nominclature (`cache_key` --> is for the lookup, `entity_tag` is for the version)
* removed the non-standard header `x-alternate-cache-key`
* update gemfile dependency versions

Future work should include:
* moving from `x-cache` header to the standard `cache-status` header
* removing the UA match for IE <8 's inconsistency with XML-HTTP-Request