### PR TITLE
Remove IE8 workaround for ajax calls

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     response_bank (1.2.0)
       msgpack
-      useragent
 
 GEM
   remote: https://rubygems.org/
@@ -100,7 +99,7 @@ GEM
     minitest (5.18.0)
     mocha (2.0.2)
       ruby2_keywords (>= 0.0.5)
-    msgpack (1.6.1)
+    msgpack (1.7.0)
     net-imap (0.3.4)
       date
       net-protocol
@@ -176,7 +175,6 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    useragent (0.16.10)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'useragent'
 
 module ResponseBank
   class Middleware
@@ -25,9 +24,6 @@ module ResponseBank
         if [200, 404, 301, 304].include?(status)
           headers['ETag'] = env['cacheable.key']
 
-          if ie_ajax_request?(env)
-            headers["Expires"] = "-1"
-          end
         end
 
         if [200, 404, 301].include?(status) && env['cacheable.miss']
@@ -79,14 +75,5 @@ module ResponseBank
       Time.now.to_i
     end
 
-    def ie_ajax_request?(env)
-      return false unless !env[USER_AGENT].nil? && !env[USER_AGENT].empty?
-
-      if env[REQUESTED_WITH] == "XmlHttpRequest" || env[ACCEPT] == "application/json"
-        UserAgent.parse(env["HTTP_USER_AGENT"]).is_a?(UserAgent::Browsers::InternetExplorer)
-      else
-        false
-      end
-    end
   end
 end

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  s.add_runtime_dependency("useragent")
   s.add_runtime_dependency("msgpack")
 
   s.add_development_dependency("minitest", ">= 5.18.0")

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -300,46 +300,4 @@ class MiddlewareTest < Minitest::Test
     assert_equal('client', env['cacheable.store'])
     assert_equal('"etag_value"', headers['ETag'])
   end
-
-  def test_ie_ajax
-    ware = ResponseBank::Middleware.new(method(:already_cached_app))
-    env = Rack::MockRequest.env_for("http://example.com/index.html")
-
-    assert(!ware.send(:ie_ajax_request?, env))
-
-    env = Rack::MockRequest.env_for("http://example.com/index.html")
-    env["HTTP_USER_AGENT"] = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
-
-    assert(!ware.send(:ie_ajax_request?, env))
-
-    env = Rack::MockRequest.env_for("http://example.com/index.html")
-    env["HTTP_USER_AGENT"] = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
-    env["HTTP_X_REQUESTED_WITH"] = "XmlHttpRequest"
-
-    assert(ware.send(:ie_ajax_request?, env))
-
-    env = Rack::MockRequest.env_for("http://example.com/index.html")
-    env["HTTP_USER_AGENT"] = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
-    env["HTTP_ACCEPT"] = "application/json"
-
-    assert(ware.send(:ie_ajax_request?, env))
-  end
-
-  def test_cache_hit_server_with_ie_ajax
-    ResponseBank.cache_store.expects(:write).times(0)
-
-    env = Rack::MockRequest.env_for("http://example.com/index.html")
-    env["HTTP_USER_AGENT"] = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"
-    env["HTTP_X_REQUESTED_WITH"] = "XmlHttpRequest"
-
-    ware = ResponseBank::Middleware.new(method(:already_cached_app))
-    result = ware.call(env)
-    headers = result[1]
-
-    assert(env['cacheable.cache'])
-    assert(!env['cacheable.miss'])
-    assert_equal('server', env['cacheable.store'])
-    assert_equal('"etag_value"', headers['ETag'])
-    assert_equal("-1", headers['Expires'])
-  end
 end


### PR DESCRIPTION
In IE 5.5 to IE 8, XML HTTP Requests (ajax) using the ActiveX object had compatibility issues with expires headers and etags. Since IE has long been deprecated by microsoft, the work around is no longer needed. This also allows the removal of the useragent dependency