### PR TITLE
add unversioned test to the cache

### DIFF
--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -84,7 +84,7 @@ module ResponseBank
       response = serve_from_browser_cache(entity_tag_hash, @env['HTTP_IF_NONE_MATCH'])
       return response if response
 
-      response = serve_from_cache(cache_key_hash, entity_tag_hash, @cache_age_tolerance)
+      response = serve_from_cache(cache_key_hash, @serve_unversioned ? "*" : entity_tag_hash, @cache_age_tolerance)
       return response if response
 
       # No cache hit; this request cannot be handled from cache.

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ResponseBank
-  VERSION = "1.2.1"
+  VERSION = "1.2.2"
 end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -177,7 +177,7 @@ class ResponseCacheHandlerTest < Minitest::Test
   def test_serve_unversioned_cacheable_entry
     assert(@controller.respond_to?(:serve_unversioned_cacheable_entry?, true))
     @controller.expects(:serve_unversioned_cacheable_entry?).returns(true).times(1)
-    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry)
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(page_cache_entry(false))
     expect_page_rendered(page)
     assert_cache_miss(false, 'server')
   end


### PR DESCRIPTION
When serve_unversioned is true, the entity_tag should be set to "*" for any match in the cache.