### PR TITLE
Fix a bug because headers["Content-Encoding"] can be nil

### DIFF
--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -146,7 +146,7 @@ module ResponseBank
         @headers.merge!(headers)
 
         # if a cache key hit and client doesn't match encoding, return the raw body
-        if !@env['HTTP_ACCEPT_ENCODING'].to_s.include?(@headers['Content-Encoding'])
+        if @headers['Content-Encoding'] && !@env['HTTP_ACCEPT_ENCODING'].to_s.include?(@headers['Content-Encoding'])
           ResponseBank.log("uncompressing payload for client as client doesn't require encoding")
           body = ResponseBank.decompress(body, @headers['Content-Encoding'])
           @headers.delete('Content-Encoding')


### PR DESCRIPTION
# Describe

After deploying the change in SFR, we are seeing a lot of errors in canary: https://app.bugsnag.com/shopify/storefront-renderer/errors/642e06e80ccf5700087ab5d0?filters[event.since]=1h&filters[error.status]=open&filters[app.release_stage]=canary&pivot_tab=event

The error:

```
bundler/gems/response_bank-92ad9b55c7c9/lib/response_bank/response_cache_handler.rb:149:in `include?': no implicit conversion of nil into String

        if !@env['HTTP_ACCEPT_ENCODING'].to_s.include?(@headers['Content-Encoding'])
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ (TypeError)
    from bundler/gems/response_bank-92ad9b55c7c9/lib/response_bank/response_cache_handler.rb:149:in `serve_from_cache'
    from bundler/gems/response_bank-92ad9b55c7c9/lib/response_bank/response_cache_handler.rb:87:in `try_to_serve_from_cache'
    from bundler/gems/response_bank-92ad9b55c7c9/lib/response_bank/response_cache_handler.rb:43:in `run!'
    from /app/app/helpers/page_cache.rb:34:in `run!'
    from /app/app/controllers/responders/base_responder.rb:583:in `block in response_cache'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace.rb:72:in `block in with_span'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/context.rb:87:in `with_value'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace.rb:72:in `with_span'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace/tracer.rb:29:in `in_span'
    from /app/app/controllers/responders/base_responder.rb:572:in `response_cache'
    from /app/app/controllers/responders/base_responder.rb:260:in `block (3 levels) in render'
    from /app/app/controllers/responders/base_responder.rb:681:in `block in with_locale'
    from /app/app/helpers/i18n/shop_i18n.rb:95:in `with_shop'
    from /app/app/controllers/responders/base_responder.rb:676:in `with_locale'
    from /app/app/controllers/responders/base_responder.rb:228:in `block (2 levels) in render'
    from /app/app/helpers/cdn_asset_host.rb:47:in `with_host'
    from /app/app/helpers/cdn_asset_host.rb:16:in `with_host_for_shop'
    from /app/app/controllers/responders/base_responder.rb:227:in `block in render'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace.rb:72:in `block in with_span'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/context.rb:87:in `with_value'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace.rb:72:in `with_span'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace/tracer.rb:29:in `in_span'
    from /app/app/controllers/responders/base_responder.rb:226:in `render'
    from /app/app/controllers/responders/base_html_responder.rb:55:in `render'
    from /app/app/controllers/responders/base_responder.rb:60:in `render'
    from /app/app/controllers/base_controller.rb:66:in `render'
    from /app/app/storefront_app.rb:83:in `call'
    from /app/gems/online_store_editor/lib/online_store_editor/middleware.rb:31:in `call'
    from gems/rack-2.2.6.4/lib/rack/method_override.rb:24:in `call'
    from /app/app/middlewares/bearer_token_authorization_middleware.rb:62:in `call'
    from /app/app/middlewares/exception_middleware.rb:30:in `call_with_exception_handling'
    from /app/app/middlewares/exception_middleware.rb:23:in `call'
    from bundler/gems/response_bank-92ad9b55c7c9/lib/response_bank/middleware.rb:21:in `call'
    from /app/app/middlewares/commit_flash_middleware.rb:6:in `call'
    from gems/rack-2.2.6.4/lib/rack/session/abstract/id.rb:266:in `context'
    from gems/rack-2.2.6.4/lib/rack/session/abstract/id.rb:260:in `call'
    from /app/app/middlewares/drop_memoizer_middleware.rb:13:in `call'
    from /app/app/middlewares/prefetcher_middleware.rb:13:in `call'
    from /app/app/middlewares/high_throughput_middleware.rb:20:in `call'
    from /app/app/middlewares/data_stores_middleware.rb:295:in `call'
    from /app/app/middlewares/user_agent_sniffer_middleware.rb:12:in `call'
    from /app/app/middlewares/routing_timing_metrics_middleware.rb:12:in `call'
    from /app/app/middlewares/last_request_middleware.rb:12:in `call'
    from /app/app/middlewares/ip_metadata_middleware.rb:12:in `call'
    from /app/app/middlewares/headers_middleware.rb:12:in `call'
    from /app/app/middlewares/vm_stat_middleware.rb:113:in `call'
    from /app/app/middlewares/verifier_middleware.rb:132:in `call'
    from /app/app/middlewares/sorting_hat_middleware.rb:24:in `call'
    from /app/app/middlewares/static_routes_middleware.rb:35:in `call'
    from gems/rack-2.2.6.4/lib/rack/head.rb:12:in `call'
    from gems/rack-2.2.6.4/lib/rack/chunked.rb:98:in `call'
    from gems/rack-2.2.6.4/lib/rack/content_length.rb:17:in `call'
    from /app/app/middlewares/tracing_middleware.rb:72:in `block (3 levels) in call'
    from /app/gems/sonic/lib/sonic/buffered_trace_producer.rb:44:in `with_buffer'
    from /app/app/middlewares/tracing_middleware.rb:65:in `block (2 levels) in call'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace.rb:72:in `block in with_span'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/context.rb:87:in `with_value'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/trace.rb:72:in `with_span'
    from /app/app/middlewares/tracing_middleware.rb:64:in `block in call'
    from gems/opentelemetry-api-1.1.0/lib/opentelemetry/context.rb:71:in `with_current'
    from /app/app/middlewares/tracing_middleware.rb:59:in `call'
    from /app/app/middlewares/profiling_middleware.rb:25:in `call'
    from /app/app/middlewares/panic_exception_middleware.rb:6:in `call'
    from /app/app/middlewares/exception_middleware.rb:30:in `call_with_exception_handling'
    from /app/app/middlewares/exception_middleware.rb:21:in `block in call'
    from /app/lib/exception_reporter.rb:67:in `with_rack_env'
    from /app/app/middlewares/exception_middleware.rb:21:in `call'
    from gems/shopify_metrics-1.16.0/lib/shopify_metrics/middlewares/request_metrics_middleware.rb:48:in `call'
    from /app/app/middlewares/request_stats_middleware.rb:50:in `call'
    from /app/app/middlewares/metafield_tracking_middleware.rb:18:in `call'
    from /app/app/middlewares/handle_poor_request_input_middleware.rb:23:in `call'
    from /app/app/middlewares/compressed_input_middleware.rb:12:in `call'
    from /app/lib/canonical_logger.rb:191:in `call'
    from gems/rack-utf8_sanitizer-1.8.0/lib/rack/utf8_sanitizer.rb:28:in `call'
    from /app/app/middlewares/timeout_middleware.rb:28:in `call'
    from gems/unicorn-6.1.0/lib/unicorn/http_server.rb:634:in `process_client'
    from /app/app/patches/diagnostics_unicorn_middleware_hook.rb:36:in `process_client'
    from gems/unicorn-6.1.0/lib/unicorn/http_server.rb:739:in `worker_loop'
    from /app/app/patches/diagnostics_unicorn_middleware_hook.rb:31:in `worker_loop'
    from gems/unicorn-6.1.0/lib/unicorn/http_server.rb:547:in `spawn_missing_workers'
    from gems/unicorn-6.1.0/lib/unicorn/http_server.rb:143:in `start'
    from gems/unicorn-6.1.0/bin/unicorn:128:in `<top (required)>'
    from bin/unicorn:25:in `load'
    from bin/unicorn:25:in `<top (required)>'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:58:in `load'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:58:in `kernel_load'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/cli/exec.rb:23:in `run'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/cli.rb:491:in `exec'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/cli.rb:34:in `dispatch'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/cli.rb:28:in `start'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/exe/bundle:45:in `block in <top (required)>'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
    from /app/.local/share/gem/ruby/3.2.0/gems/bundler-2.4.6/exe/bundle:33:in `<top (required)>'
    from /usr/local/ruby/bin/bundle:25:in `load'
    from /usr/local/ruby/bin/bundle:25:in `<main>'
```