### PR TITLE
fix cache lookup to use quoted etag value

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    response_bank (1.3.1)
+    response_bank (1.3.2)
       brotli
       msgpack
 

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -123,7 +123,7 @@ module ResponseBank
         if match_entity_tag == "*"
           ResponseBank.log("Cache hit: server (unversioned)")
           # page tolerance only applies for versioned + etag mismatch
-        elsif etag_matches?(headers['ETag'], match_entity_tag)
+        elsif etag_matches?(headers['ETag'], %{"#{match_entity_tag}"})
           ResponseBank.log("Cache hit: server")
         else
           # cache miss; check to see if any parallel requests already are regenerating the cache
@@ -172,7 +172,7 @@ module ResponseBank
 
       # strictly speaking an unquoted etag is not valid, yet common
       # to avoid unintended greedy matches in we check for naked entity then includes with quoted entity values
-      if_none_match == "*" || if_none_match == entity_tag || if_none_match.include?(%{"#{entity_tag}"})
+      if_none_match == '*' || if_none_match == entity_tag || if_none_match.include?(%{"#{entity_tag}"})
     end
 
     def stale_while_revalidate?(timestamp, cache_age_tolerance)

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ResponseBank
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -57,7 +57,7 @@ class ResponseBankControllerTest < Minitest::Test
   def test_server_cache_hit
     controller.request.env['response_bank.server_cache_encoding'] = 'br'
     @cache_store.expects(:read).returns(page_serialized)
-    ResponseBank::ResponseCacheHandler.any_instance.expects(:entity_tag_hash).returns('*').at_least_once
+    ResponseBank::ResponseCacheHandler.any_instance.expects(:entity_tag_hash).returns('v1').at_least_once
     controller.expects(:render).with(plain: '<body>hi.</body>', status: 200)
 
     controller.send(:response_cache) {}
@@ -79,6 +79,6 @@ class ResponseBankControllerTest < Minitest::Test
   end
 
   def page_serialized
-    MessagePack.dump([200, {"Content-Type" => "text/html", "Content-Encoding" => "br"}, ResponseBank.compress("<body>hi.</body>", "br"), 1331765506])
+    MessagePack.dump([200, {"Content-Type" => "text/html", "Content-Encoding" => "br", "ETag" => '"v1"'}, ResponseBank.compress("<body>hi.</body>", "br"), 1331765506])
   end
 end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -31,7 +31,7 @@ class ResponseCacheHandlerTest < Minitest::Test
 
   def page(cache_hit = true, compression="br")
     etag = cache_hit ? handler.entity_tag_hash : "not-cached"
-    [200, {"Content-Type" => "text/html", "ETag" => etag, "Content-Encoding" => compression}, ResponseBank.compress("<body>cached output</body>", compression), 1331765506]
+    [200, {"Content-Type" => "text/html", "ETag" => %{"#{etag}"}, "Content-Encoding" => compression}, ResponseBank.compress("<body>cached output</body>", compression), 1331765506]
   end
 
   def page_cache_entry(cache_hit = true, compression="br")
@@ -40,7 +40,7 @@ class ResponseCacheHandlerTest < Minitest::Test
 
   def page_uncompressed(cache_hit = true)
     etag = cache_hit ? handler.entity_tag_hash : "not-cached"
-    [200, {"Content-Type" => "text/html", "ETag" => etag}, "<body>cached output</body>", 1331765506]
+    [200, {"Content-Type" => "text/html", "ETag" => %{"#{etag}"}}, "<body>cached output</body>", 1331765506]
   end
 
   def test_cache_miss_block_is_only_called_once_if_it_return_nil


### PR DESCRIPTION
This fixes the cache key loookup bug that was introduced in 1.3.1