### PR TITLE
Allow skipping the browser cache

### DIFF
--- a/lib/response_bank/controller.rb
+++ b/lib/response_bank/controller.rb
@@ -21,6 +21,10 @@ module ResponseBank
       params[:fill_cache] == "true"
     end
 
+    def skip_browser_cache?
+      false
+    end
+
     def serve_unversioned_cacheable_entry?
       false
     end
@@ -48,6 +52,7 @@ module ResponseBank
         cache_age_tolerance: cache_age_tolerance_in_seconds,
         serve_unversioned: serve_unversioned_cacheable_entry?,
         force_refill_cache: force_refill_cache?,
+        skip_browser_cache: skip_browser_cache?,
         headers: response.headers,
         &block
       )

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -13,6 +13,7 @@ module ResponseBank
       serve_unversioned:,
       headers:,
       force_refill_cache: false,
+      skip_browser_cache: false,
       cache_store: ResponseBank.cache_store,
       &block
     )
@@ -25,6 +26,7 @@ module ResponseBank
 
       @serve_unversioned = serve_unversioned
       @force_refill_cache = force_refill_cache
+      @skip_browser_cache = skip_browser_cache
       @cache_store = cache_store
       @headers = headers || {}
       @key_schema_version = @env.key?('cacheable.key_version') ? @env.key['cacheable.key_version'] : CACHE_KEY_SCHEMA_VERSION
@@ -81,8 +83,10 @@ module ResponseBank
 
     def try_to_serve_from_cache
       # Etag
-      response = serve_from_browser_cache(entity_tag_hash, @env['HTTP_IF_NONE_MATCH'])
-      return response if response
+      unless @skip_browser_cache
+        response = serve_from_browser_cache(entity_tag_hash, @env['HTTP_IF_NONE_MATCH'])
+        return response if response
+      end
 
       response = serve_from_cache(cache_key_hash, @serve_unversioned ? "*" : entity_tag_hash, @cache_age_tolerance)
       return response if response


### PR DESCRIPTION
There are some cases where we might want to skip out on returning the browser cache. We have a case internally where we cannot update the version on the cache key at the right time and so rather than forcefully updating that version right before a request under certain conditions, we are instead just skipping the browser cache.

This especially causes problems when we set the `cacheable.versioned-cache-expiry` because the browser's cache key may not be expired yet, but the underlying cache key is. 

There is likely a better fix to the above problem using the Cache-Control headers, but this is a fairly simple fix for now that allows us to move forward.