### PR TITLE
Retry on `Zlib::BufError`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.7', '3.2' ]
+        ruby: [ '2.7', '3.3' ]
         actionpack: [ '6.1', '7.0', 'edge' ]
+        exclude:
+          - ruby: '2.7'
+            actionpack: edge
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/actionpack_${{ matrix.actionpack }}.gemfile

--- a/test/response_bank_test.rb
+++ b/test/response_bank_test.rb
@@ -67,4 +67,20 @@ class ResponseBankTest < Minitest::Test
   def test_cache_key_for_date
     assert_equal("2020-01-01", ResponseBank.cache_key_for(Date.new(2020, 1, 1)))
   end
+
+  def test_compress_retries_once_on_zlib_buferror
+    content = 'mycontent'
+    compressed_content = Zlib.gzip(content, level: Zlib::BEST_COMPRESSION)
+    Zlib.stubs(:gzip).raises(Zlib::BufError).then.returns(compressed_content)
+
+    assert_equal(compressed_content, ResponseBank.compress(content, "gzip"))
+  end
+
+  def test_compress_retries_once_on_zlib_buferror_and_raises_if_it_happens_again
+    Zlib.stubs(:gzip).raises(Zlib::BufError)
+
+    assert_raises(Zlib::BufError) do
+      ResponseBank.compress("mycontent", "gzip")
+    end
+  end
 end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -125,7 +125,7 @@ class ResponseCacheHandlerTest < Minitest::Test
     _status, _headers, _body, _timestamp = empty_page
     ResponseBank.expects(:decompress).never
 
-    status, headers, body = handler.run!
+    status, headers, _body = handler.run!
 
     assert_equal(_status, status)
     assert_equal(_headers['Content-Type'], headers["Content-Type"])
@@ -143,7 +143,7 @@ class ResponseCacheHandlerTest < Minitest::Test
 
     ResponseBank.expects(:decompress).returns(_body).once
 
-    status, headers, body = handler.run!
+    status, headers, _body = handler.run!
 
     assert_equal(_status, status)
     assert_equal(_headers['Content-Type'], headers["Content-Type"])


### PR DESCRIPTION
This error [happens sporadically](https://github.com/ruby/zlib/issues/49) for currently unknown reasons. I fixed one race condition in https://github.com/ruby/zlib/pull/74, but we are still getting tons of errors even with that patch. For now, the best solution is to retry once, knowing probability is on our side (a la https://github.com/opal/opal/pull/2463).