### PR TITLE
Add Speculation-Rules to the list of cacheable headers

### DIFF
--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -4,7 +4,7 @@ module ResponseBank
   class Middleware
     # Limit the cached headers
     # TODO: Make this lowercase/case-insentitive as per rfc2616 §4.2
-    CACHEABLE_HEADERS = ["Location", "Content-Type", "ETag", "Content-Encoding", "Last-Modified", "Cache-Control", "Expires", "Link", "Surrogate-Keys", "Cache-Tags"].freeze
+    CACHEABLE_HEADERS = ["Location", "Content-Type", "ETag", "Content-Encoding", "Last-Modified", "Cache-Control", "Expires", "Link", "Surrogate-Keys", "Cache-Tags", "Speculation-Rules"].freeze
 
     REQUESTED_WITH = "HTTP_X_REQUESTED_WITH"
     ACCEPT = "HTTP_ACCEPT"

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -49,7 +49,7 @@ def cached_spec_rules(env)
   env['cacheable.unversioned-key'] = 'cached_moved_cache_key'
   env['cacheable.store'] = 'server'
 
-  [200, { 'Speculation-Rules' => 'https://shopify.com/specrules.json' }, []]
+  [200, { 'Speculation-Rules' => '\"https://shopify.com/specrules.json\"' }, []]
 end
 
 def spec_rules(env)
@@ -58,7 +58,7 @@ def spec_rules(env)
   env['cacheable.key']   = 'etag_value'
   env['cacheable.unversioned-key'] = 'moved_cache_key'
 
-  [200, { 'Speculation-Rules' => 'https://shopify.com/specrules.json' }, []]
+  [200, { 'Speculation-Rules' => '\"https://shopify.com/specrules.json\"' }, []]
 end
 
 def cacheable_app(env)

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -42,6 +42,25 @@ def moved(env)
   [301, { 'Location' => 'http://shopify.com', 'Content-Type' => 'text/plain' }, []]
 end
 
+def cached_spec_rules(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss']  = false
+  env['cacheable.key']   = 'etag_value'
+  env['cacheable.unversioned-key'] = 'cached_moved_cache_key'
+  env['cacheable.store'] = 'server'
+
+  [200, { 'Speculation-Rules' => 'https://shopify.com/specrules.json' }, []]
+end
+
+def spec_rules(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss']  = true
+  env['cacheable.key']   = 'etag_value'
+  env['cacheable.unversioned-key'] = 'moved_cache_key'
+
+  [200, { 'Speculation-Rules' => 'https://shopify.com/specrules.json' }, []]
+end
+
 def cacheable_app(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = true
@@ -146,6 +165,26 @@ class MiddlewareTest < Minitest::Test
     assert_equal('"etag_value"', headers['ETag'])
     assert_equal('http://shopify.com', headers['Location'])
     assert(!headers['Content-Encoding'])
+  end
+
+  def test_cache_hit_and_specrules
+    ResponseBank.cache_store.expects(:write).never
+
+    ware = ResponseBank::Middleware.new(method(:cached_spec_rules))
+    result = ware.call(@env)
+    headers = result[1]
+
+    assert_equal('"https://shopify.com/specrules.json"', headers['Speculation-Rules'])
+  end
+
+  def test_cache_miss_and_specrules
+    ResponseBank.cache_store.expects(:write).once
+
+    ware = ResponseBank::Middleware.new(method(:spec_rules))
+    result = ware.call(@env)
+    headers = result[1]
+
+    assert_equal('"https://shopify.com/specrules.json"', headers['Speculation-Rules'])
   end
 
   def test_cache_miss_and_store_limited_headers

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -49,7 +49,7 @@ def cached_spec_rules(env)
   env['cacheable.unversioned-key'] = 'cached_moved_cache_key'
   env['cacheable.store'] = 'server'
 
-  [200, { 'Speculation-Rules' => '\"https://shopify.com/specrules.json\"' }, []]
+  [200, { 'Speculation-Rules' => '"https://shopify.com/specrules.json"' }, []]
 end
 
 def spec_rules(env)
@@ -58,7 +58,7 @@ def spec_rules(env)
   env['cacheable.key']   = 'etag_value'
   env['cacheable.unversioned-key'] = 'moved_cache_key'
 
-  [200, { 'Speculation-Rules' => '\"https://shopify.com/specrules.json\"' }, []]
+  [200, { 'Speculation-Rules' => '"https://shopify.com/specrules.json"' }, []]
 end
 
 def cacheable_app(env)


### PR DESCRIPTION
In https://github.com/shop/world/pull/52153 we see that we don't have access to the theme in the case of a cached response. Therefore, it would be better to cache the Speculation-Rules header and remove it if needed, rather than to try and add it to cached responses, where we don't have all the information.