### PR TITLE
Add Shopify-Theme as a cacheable header

### DIFF
--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -4,7 +4,7 @@ module ResponseBank
   class Middleware
     # Limit the cached headers
     # TODO: Make this lowercase/case-insentitive as per rfc2616 §4.2
-    CACHEABLE_HEADERS = ["Location", "Content-Type", "ETag", "Content-Encoding", "Last-Modified", "Cache-Control", "Expires", "Link", "Surrogate-Keys", "Cache-Tags", "Speculation-Rules"].freeze
+    CACHEABLE_HEADERS = ["Location", "Content-Type", "ETag", "Content-Encoding", "Last-Modified", "Cache-Control", "Expires", "Link", "Surrogate-Keys", "Cache-Tags", "Speculation-Rules", "Shopify-Theme"].freeze
 
     REQUESTED_WITH = "HTTP_X_REQUESTED_WITH"
     ACCEPT = "HTTP_ACCEPT"

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ResponseBank
-  VERSION = "1.3.6"
+  VERSION = "1.3.7"
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -61,6 +61,25 @@ def spec_rules(env)
   [200, { 'Speculation-Rules' => '"https://shopify.com/specrules.json"' }, []]
 end
 
+def cached_shopify_theme(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss']  = false
+  env['cacheable.key']   = 'etag_value'
+  env['cacheable.unversioned-key'] = 'cached_shopify_theme_cache_key'
+  env['cacheable.store'] = 'server'
+
+  [200, { 'Shopify-Theme' => 'dawn-v1.2.3' }, []]
+end
+
+def shopify_theme(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss']  = true
+  env['cacheable.key']   = 'etag_value'
+  env['cacheable.unversioned-key'] = 'shopify_theme_cache_key'
+
+  [200, { 'Shopify-Theme' => 'dawn-v1.2.3' }, []]
+end
+
 def cacheable_app(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = true
@@ -185,6 +204,26 @@ class MiddlewareTest < Minitest::Test
     headers = result[1]
 
     assert_equal('"https://shopify.com/specrules.json"', headers['Speculation-Rules'])
+  end
+
+  def test_cache_hit_and_shopify_theme
+    ResponseBank.cache_store.expects(:write).never
+
+    ware = ResponseBank::Middleware.new(method(:cached_shopify_theme))
+    result = ware.call(@env)
+    headers = result[1]
+
+    assert_equal('dawn-v1.2.3', headers['Shopify-Theme'])
+  end
+
+  def test_cache_miss_and_shopify_theme
+    ResponseBank.cache_store.expects(:write).once
+
+    ware = ResponseBank::Middleware.new(method(:shopify_theme))
+    result = ware.call(@env)
+    headers = result[1]
+
+    assert_equal('dawn-v1.2.3', headers['Shopify-Theme'])
   end
 
   def test_cache_miss_and_store_limited_headers


### PR DESCRIPTION
As outlined in https://shopify.slack.com/archives/C098UMNCU3A/p1758527247056459, I think we need a different mechanism than the `Speculation-Rules` header to distinguish Horizon themes in cache hits.

This PR adds a `Shopify-Theme` header to the cacheable headers. Once that happens, we can add such a header in SFR for cache misses that match the Horizon theme detection, and use it on cache hits to inject Horizon-specific speculation rules. 

There's a related PR on the SFR side: https://github.com/shop/world/pull/199868
It adds the use of this header as part of the speculation rules logic.