### PR TITLE
Add Support for Caching 422 (Unprocessable Entity) Responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 ## Features
 
-* Serve gzip'd content
+* Serve gzip'd and brotli-compressed content
 * Add ETag and 304 Not Modified headers
 * Generational caching
 * No explicit expiry
+* Caches 200 (OK), 301 (Moved Permanently), 404 (Not Found), and 422 (Unprocessable Entity) responses
 
 ## Support
 

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -21,11 +21,11 @@ module ResponseBank
       status, headers, body = @app.call(env)
 
       if env['cacheable.cache']
-        if [200, 404, 301, 304].include?(status)
+        if [200, 404, 301, 304, 422].include?(status)
           headers['ETag'] = %{"#{env['cacheable.key']}"}
         end
 
-        if [200, 404, 301].include?(status) && env['cacheable.miss']
+        if [200, 404, 301, 422].include?(status) && env['cacheable.miss']
           # Flatten down the result so that it can be stored to memcached.
           if body.is_a?(String)
             body_string = body

--- a/test/controller_test.rb
+++ b/test/controller_test.rb
@@ -72,6 +72,17 @@ class ResponseBankControllerTest < Minitest::Test
     controller.send(:response_cache) {}
   end
 
+  def test_server_cache_hit_unprocessable_entity
+    controller.request.env['response_bank.server_cache_encoding'] = 'br'
+    @cache_store.expects(:read).returns(unprocessable_entity_serialized)
+    ResponseBank::ResponseCacheHandler.any_instance.expects(:entity_tag_hash).returns('v1').at_least_once
+
+    body = JSON.dump({errors: {email: ["is invalid"]}})
+    controller.expects(:render).with(plain: body, status: 422)
+
+    controller.send(:response_cache) {}
+  end
+
   private
 
   def controller
@@ -80,5 +91,10 @@ class ResponseBankControllerTest < Minitest::Test
 
   def page_serialized
     MessagePack.dump([200, {"Content-Type" => "text/html", "Content-Encoding" => "br", "ETag" => '"v1"'}, ResponseBank.compress("<body>hi.</body>", "br"), 1331765506])
+  end
+
+  def unprocessable_entity_serialized
+    body = JSON.dump({errors: {email: ["is invalid"]}})
+    MessagePack.dump([422, {"Content-Type" => "application/json", "Content-Encoding" => "br", "ETag" => '"v1"'}, ResponseBank.compress(body, "br"), 1331765506])
   end
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -113,6 +113,27 @@ def client_hit_app(env)
   [304, { 'Content-Type' => 'text/plain' }, body]
 end
 
+def unprocessable_entity(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss']  = true
+  env['cacheable.key']   = 'etag_value'
+  env['cacheable.unversioned-key'] = 'unprocessable_entity_cache_key'
+
+  body = [JSON.dump({errors: {email: ["is invalid"]}})]
+  [422, { 'Content-Type' => 'application/json' }, body]
+end
+
+def cached_unprocessable_entity(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss']  = false
+  env['cacheable.key']   = 'etag_value'
+  env['cacheable.unversioned-key'] = 'cached_unprocessable_entity_cache_key'
+  env['cacheable.store'] = 'server'
+
+  body = [JSON.dump({errors: {email: ["is invalid"]}})]
+  [422, { 'Content-Type' => 'application/json' }, body]
+end
+
 class MiddlewareTest < Minitest::Test
   def setup
     @original_cache_store = ResponseBank.cache_store
@@ -357,6 +378,63 @@ class MiddlewareTest < Minitest::Test
     assert(@env['cacheable.cache'])
     assert(!@env['cacheable.miss'])
     assert_equal('client', @env['cacheable.store'])
+    assert_equal('"etag_value"', headers['ETag'])
+  end
+
+  def test_cache_miss_and_unprocessable_entity
+    ResponseBank.cache_store.expects(:write).once
+
+    ware = ResponseBank::Middleware.new(method(:unprocessable_entity))
+    result = ware.call(@env)
+    headers = result[1]
+
+    assert_equal('"etag_value"', headers['ETag'])
+    assert_equal('miss', headers['X-Cache'])
+  end
+
+  def test_cache_hit_and_unprocessable_entity
+    ResponseBank.cache_store.expects(:write).never
+
+    ware = ResponseBank::Middleware.new(method(:cached_unprocessable_entity))
+    result = ware.call(@env)
+    headers = result[1]
+
+    assert_equal('"etag_value"', headers['ETag'])
+    assert_equal('hit, server', headers['X-Cache'])
+  end
+
+  def test_cache_miss_and_store_unprocessable_entity_with_br
+    ResponseBank::Middleware.any_instance.stubs(timestamp: 424242)
+    body = JSON.dump({errors: {email: ["is invalid"]}})
+
+    ResponseBank.cache_store.expects(:write).with(
+      'unprocessable_entity_cache_key',
+      MessagePack.dump([422, {'Content-Type' => 'application/json', 'ETag' => '"etag_value"', 'Content-Encoding' => 'br'}, ResponseBank.compress(body, 'br'), 424242]),
+      raw: true,
+      expires_in: nil,
+    ).once
+
+    @env['HTTP_ACCEPT_ENCODING'] = 'deflate, br, gzip'
+
+    ware = ResponseBank::Middleware.new(method(:unprocessable_entity))
+    result = ware.call(@env)
+    headers = result[1]
+
+    assert(@env['cacheable.cache'])
+    assert(@env['cacheable.miss'])
+    assert_equal('"etag_value"', headers['ETag'])
+    assert_equal('miss', headers['X-Cache'])
+    assert_equal('br', headers['Content-Encoding'])
+  end
+
+  def test_unprocessable_entity_gets_etag
+    ware = ResponseBank::Middleware.new(method(:unprocessable_entity))
+    result = ware.call(@env)
+
+    status = result[0]
+    headers = result[1]
+
+    assert_equal(422, status)
     assert_equal('"etag_value"', headers['ETag'])
   end
 end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -44,6 +44,16 @@ class ResponseCacheHandlerTest < Minitest::Test
     [200, {"Content-Type" => "text/html", "ETag" => %{"#{etag}"}}, "<body>cached output</body>", 1331765506]
   end
 
+  def unprocessable_entity_page(cache_hit = true, compression="br")
+    etag = cache_hit ? handler.entity_tag_hash : "not-cached"
+    body = JSON.dump({errors: {field: ["is invalid"]}})
+    [422, {"Content-Type" => "application/json", "ETag" => %{"#{etag}"}, "Content-Encoding" => compression}, ResponseBank.compress(body, compression), 1331765506]
+  end
+
+  def unprocessable_entity_cache_entry(cache_hit = true, compression="br")
+    MessagePack.dump(unprocessable_entity_page(cache_hit, compression))
+  end
+
   def test_cache_miss_block_is_only_called_once_if_it_return_nil
     called = 0
     my_handler = ResponseBank::ResponseCacheHandler.new(
@@ -277,5 +287,34 @@ class ResponseCacheHandlerTest < Minitest::Test
     assert_equal(content_encoding, headers["Content-Encoding"]) if content_encoding
 
     body
+  end
+
+  def test_server_cache_hit_unprocessable_entity
+    controller.request.env['response_bank.server_cache_encoding'] = 'br'
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(unprocessable_entity_cache_entry(true, 'br'))
+
+    body = JSON.dump({errors: {field: ["is invalid"]}})
+    page_decompressed = [422, {"Content-Type" => "application/json", "ETag" => handler.entity_tag_hash, "Content-Encoding" => 'br'}, body, 1331765506]
+
+    expect_page_rendered(page_decompressed, nil)
+    assert_cache_miss(false, 'server')
+  end
+
+  def test_unprocessable_entity_decompression
+    controller.request.env['response_bank.server_cache_encoding'] = 'gzip'
+    cache_entry = unprocessable_entity_page(true, 'br')
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(MessagePack.dump(cache_entry))
+    controller.request.env['HTTP_ACCEPT_ENCODING'] = 'gzip'
+
+    _status, _headers, _body, _timestamp = cache_entry
+
+    ResponseBank.expects(:decompress).returns(_body).once
+
+    status, headers, _body = handler.run!
+
+    assert_equal(_status, status)
+    assert_equal(_headers['Content-Type'], headers["Content-Type"])
+    assert_nil(headers["Content-Encoding"])
+    assert_cache_miss(false, 'server')
   end
 end


### PR DESCRIPTION
## Summary

This PR extends ResponseBank's caching capabilities to include **422 (Unprocessable Entity)** responses alongside the existing support for 200, 301, and 404 status codes. This allows API validation error responses to be cached, reducing redundant processing for frequently repeated invalid requests.

## Motivation

422 responses are commonly used in REST APIs to indicate that the request was well-formed but contains semantic errors (e.g., validation failures). These responses are typically:
- **Deterministic**: The same invalid input produces the same validation errors
- **Expensive to compute**: Validation logic may involve multiple checks, database queries, or complex business rules
- **Frequently repeated**: Users or automated systems may repeatedly submit similar invalid requests

By caching 422 responses, we can:
- Reduce server load from repeated validation of the same invalid inputs
- Improve API response times for validation errors
- Maintain consistency with existing caching behavior for other static responses (301, 404)
