### PR TITLE
Reduce the Brotli compression level to 4

### DIFF
--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -48,7 +48,7 @@ module ResponseBank
           end
         end
       when 'br'
-        Brotli.deflate(content, mode: :text, quality: 7)
+        Brotli.deflate(content, mode: :text, quality: 4)
       else
         raise ArgumentError, "Unsupported encoding: #{encoding}"
       end


### PR DESCRIPTION
Cloudflare uses Brotli level 4 compression by default. 

https://blog.cloudflare.com/this-is-brotli-from-origin/#brotli-compression-to-11

From Google:

> [Brotli level 4: ](https://www.google.com/search?sca_esv=289e7c278657c79e&rlz=1C5GCCM_en&cs=0&q=Brotli+level+4&sa=X&ved=2ahUKEwjtsLP1sL2QAxV4ITQIHXUbFGwQxccNegQICRAD&mstk=AUtExfAR4f9nfy1mnxedw-MeVz8sM2d57WJPYVOHbmROkR7_3CsGYm345kzQgp53l0WK83LJCyhIylC_l0VQCvwJQyyZ8wq3eoMaVP2ze4Drx6bWxn7YtxPm4WdMEPzMsUwdq7CbticgoZzKBL0K2IUUk_GNtE57ia_z0nokDZ2_Jj8VoL8&csui=3)This level offers a good balance between compression efficiency and speed, often providing a comparable or better compression ratio than gzip level 6, with similar or slightly slower compression times. Cloudflare, for example, uses level 4 for dynamic Brotli compression.
[Brotli level 5: ](https://www.google.com/search?sca_esv=289e7c278657c79e&rlz=1C5GCCM_en&cs=0&q=Brotli+level+5&sa=X&ved=2ahUKEwjtsLP1sL2QAxV4ITQIHXUbFGwQxccNegQIDxAD&mstk=AUtExfAR4f9nfy1mnxedw-MeVz8sM2d57WJPYVOHbmROkR7_3CsGYm345kzQgp53l0WK83LJCyhIylC_l0VQCvwJQyyZ8wq3eoMaVP2ze4Drx6bWxn7YtxPm4WdMEPzMsUwdq7CbticgoZzKBL0K2IUUk_GNtE57ia_z0nokDZ2_Jj8VoL8&csui=3)This level can result in smaller payloads than level 4, with a slight increase in compression time. It can be a good option if slightly more compression is desired without significantly impacting performance.