### PR TITLE
Add brotli_splice gem as dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gemspec
 
 gem 'rails'
 
+gem 'brotli_splice',
+  git: 'https://github.com/shopify-playground/brotli_splice.git',
+  ref: '4ef8a22c1980ba3196f2006472d7736757f9df25'
+
 gem 'minitest', require: false, group: :test
 gem 'mocha', require: false, group: :test
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ gemspec
 
 gem 'rails'
 
-gem 'brotli_splice',
-  git: 'https://github.com/shopify-playground/brotli_splice.git',
-  ref: '4ef8a22c1980ba3196f2006472d7736757f9df25'
+source "https://pkgs.shopify.io/basic/gems/ruby" do
+  gem "brotli_splice", "= 0.1.1"
+end
 
 gem 'minitest', require: false, group: :test
 gem 'mocha', require: false, group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,7 @@ source "https://rubygems.org"
 gemspec
 
 gem 'rails'
-
-source "https://pkgs.shopify.io/basic/gems/ruby" do
-  gem "brotli_splice", "= 0.1.1"
-end
+gem "brotli_splice", "= 0.1.1"
 
 gem 'minitest', require: false, group: :test
 gem 'mocha', require: false, group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/shopify-playground/brotli_splice.git
+  revision: 4ef8a22c1980ba3196f2006472d7736757f9df25
+  ref: 4ef8a22c1980ba3196f2006472d7736757f9df25
+  specs:
+    brotli_splice (0.1.0)
+
 PATH
   remote: .
   specs:
@@ -234,6 +241,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brotli_splice!
   minitest
   mocha
   rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,7 @@
-GIT
-  remote: https://github.com/shopify-playground/brotli_splice.git
-  revision: 4ef8a22c1980ba3196f2006472d7736757f9df25
-  ref: 4ef8a22c1980ba3196f2006472d7736757f9df25
+GEM
+  remote: https://pkgs.shopify.io/basic/gems/ruby/
   specs:
-    brotli_splice (0.1.0)
+    brotli_splice (0.1.1)
 
 PATH
   remote: .
@@ -241,7 +239,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  brotli_splice!
+  brotli_splice (= 0.1.1)!
   minitest
   mocha
   rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,3 @@
-GEM
-  remote: https://pkgs.shopify.io/basic/gems/ruby/
-  specs:
-    brotli_splice (0.1.1)
-
 PATH
   remote: .
   specs:
@@ -89,6 +84,7 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     brotli (0.7.0)
+    brotli_splice (0.1.1)
     builder (3.3.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
@@ -239,7 +235,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  brotli_splice (= 0.1.1)!
+  brotli_splice (= 0.1.1)
   minitest
   mocha
   rails


### PR DESCRIPTION
## Summary

- Add `brotli_splice` as a public RubyGems.org dependency.
- Pin `brotli_splice` to `0.1.1`.
- Remove the Shopify private gem source from the dependency and lockfile.

## Testing

- `git diff --check`
- `env -u RUBY_AUTO_VERSION -u BUNDLE_MIRROR__RUBYGEMS__ORG nix shell nixpkgs#ruby_3_4 nixpkgs#brotli nixpkgs#pkg-config --command /bin/bash --noprofile --norc -c 'bundle _2.3.11_ check || bundle _2.3.11_ install; bundle _2.3.11_ exec rake test'`
