### PR TITLE
Add Brotli splice cache slot handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Brotli development headers
+        run: sudo apt-get update && sudo apt-get install -y libbrotli-dev
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     response_bank (1.3.7)
       brotli
+      brotli_splice
       msgpack
 
 GEM

--- a/README.md
+++ b/README.md
@@ -146,8 +146,16 @@ Injectors may include `ResponseBank::BrotliSpliceInjector` to document the requi
 class HtmlMetadataInjector
   include ResponseBank::BrotliSpliceInjector
 
-  PLACEHOLDER = "00000000-0000-0000-0000-000000000000"
-  PLACEHOLDER_TAG = %(<meta name="shopify-y" content="#{PLACEHOLDER}">)
+  # The per-request value spliced in on cache hits (a 36-byte UUID).
+  TOKEN_PLACEHOLDER = "00000000-0000-0000-0000-000000000000"
+  # BrotliSplice reserves the LAST 2 bytes of a slot as a fixed "\r\n" context
+  # suffix, so a slot must span 2 more bytes than its replaceable region and
+  # `replacement_length` always comes back as `slot length - 2`. We let those
+  # 2 bytes be a real "\r\n" placed after the tag, where a line break is
+  # harmless — the replaceable region is therefore `<uuid>">` (38 bytes).
+  CONTEXT_SUFFIX = "\r\n"
+  PLACEHOLDER_TAG = %(<meta name="shopify-y" content="#{TOKEN_PLACEHOLDER}">#{CONTEXT_SUFFIX})
+  SLOT = %(#{TOKEN_PLACEHOLDER}">#{CONTEXT_SUFFIX}) # 38 replaceable bytes + 2 reserved
 
   def initialize(env)
     @env = env
@@ -155,46 +163,75 @@ class HtmlMetadataInjector
 
   def prepare_response_bank_brotli_splice(body, _headers)
     body_with_placeholder = body.sub("</head>", "#{PLACEHOLDER_TAG}</head>")
-    offset = body_with_placeholder.index(PLACEHOLDER)
+    # Use a byte offset: BrotliSplice.encode addresses the slot by bytes.
+    offset = body_with_placeholder.b.index(TOKEN_PLACEHOLDER)
     return unless offset
 
     {
       body: body_with_placeholder,
       slots: [
         {
-          name: "shopify-y",
+          name: "shopify_y",
           offset: offset,
-          length: PLACEHOLDER.bytesize,
+          # Include the 2 bytes reserved for the context suffix, or the
+          # replacement below will be 2 bytes too long and silently dropped.
+          length: SLOT.bytesize,
         },
       ],
     }
   end
 
   def response_bank_brotli_splice_replacement(slot)
-    shopify_y.ljust(slot.fetch("replacement_length"))
+    # Must return EXACTLY slot["replacement_length"] bytes (== slot length - 2).
+    # If it does not, ResponseBank skips the splice and serves the neutral
+    # placeholder, so guard the length rather than assuming it.
+    replacement = %(#{shopify_y}">)
+    return unless replacement.bytesize == slot.fetch("replacement_length")
+
+    replacement
   end
 
   def replace_response_bank_brotli_splice_placeholders(body, slots)
     slots.reduce(body) do |current, slot|
       replacement = response_bank_brotli_splice_replacement(slot)
+      next current unless replacement
+
       offset = slot.fetch("html_placeholder_offset")
       length = slot.fetch("html_placeholder_length")
+      suffix = slot.fetch("context_suffix", CONTEXT_SUFFIX)
 
-      current.byteslice(0, offset) + replacement + current.byteslice(offset + length, current.bytesize)
+      # replacement + suffix must equal the original slot length (byteslice
+      # replaces `length` bytes), keeping the body byte-for-byte consistent.
+      current.byteslice(0, offset) + replacement + suffix +
+        current.byteslice(offset + length, current.bytesize)
     end
   end
 
   private
 
   def shopify_y
-    @env.fetch("HTTP_SHOPIFY_Y")
+    @env.fetch("HTTP_SHOPIFY_Y") # 36-byte UUID
   end
 end
 ```
 
-`prepare_response_bank_brotli_splice` is used on cache writes. It returns HTML containing a neutral placeholder and one slot describing that placeholder. ResponseBank stores the slot metadata with the cached Brotli body.
+`prepare_response_bank_brotli_splice` is used on cache writes. It returns HTML
+containing a neutral placeholder and one slot describing that placeholder.
+ResponseBank stores the slot metadata with the cached Brotli body. The slot's
+`offset` and `length` are **byte** offsets/counts — `BrotliSplice.encode`
+addresses the stream by bytes — so locate the placeholder on a binary view
+(`body.b.index(...)`) and size it with `bytesize`. A plain `String#index`/`size`
+silently breaks once any multi-byte UTF-8 precedes the placeholder: a character
+offset is always ≤ the byte length, so the bounds check still passes.
 
-`response_bank_brotli_splice_replacement` is used on Brotli cache hits. It must return replacement bytes with the same byte length as the stored slot.
+`response_bank_brotli_splice_replacement` is used on Brotli cache hits. It must
+return exactly `slot["replacement_length"]` bytes. Note that `replacement_length`
+is **2 fewer** than the `length` you registered in the slot: `BrotliSplice.encode`
+reserves the last 2 bytes of every slot as a fixed `\r\n` context suffix. So size
+your placeholder to include those 2 bytes (as the example does with the trailing
+`\r\n`), and have the replacement match `replacement_length`. If the byte length
+does not match, ResponseBank **silently skips the splice and serves the neutral
+placeholder** — no exception is raised — so guard the length instead of assuming it.
 
 `replace_response_bank_brotli_splice_placeholders` is used when a cached Brotli response is decompressed for a client that does not accept Brotli.
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,87 @@ This gem supports the following versions of Ruby and Rails:
     end
     ```
 
+## Brotli Splice Slots
+
+Applications that need per-request replacement inside cached Brotli HTML responses can pass an injector builder to `ResponseBank::Middleware`:
+
+```ruby
+use ResponseBank::Middleware, ->(env) { HtmlMetadataInjector.new(env) }
+```
+
+Rails applications can configure the same builder through `config.response_bank`:
+
+```ruby
+config.response_bank.brotli_splice_injector =
+  ->(env) { HtmlMetadataInjector.new(env) }
+```
+
+The injector is optional. If it is not configured, ResponseBank uses the normal Brotli compression path. Applications own the concrete injector implementation because they know how to read their request-specific metadata.
+
+Injectors may include `ResponseBank::BrotliSpliceInjector` to document the required methods:
+
+```ruby
+class HtmlMetadataInjector
+  include ResponseBank::BrotliSpliceInjector
+
+  PLACEHOLDER = "00000000-0000-0000-0000-000000000000"
+  PLACEHOLDER_TAG = %(<meta name="shopify-y" content="#{PLACEHOLDER}">)
+
+  def initialize(env)
+    @env = env
+  end
+
+  def prepare_response_bank_brotli_splice(body, _headers)
+    body_with_placeholder = body.sub("</head>", "#{PLACEHOLDER_TAG}</head>")
+    offset = body_with_placeholder.index(PLACEHOLDER)
+    return unless offset
+
+    {
+      body: body_with_placeholder,
+      slots: [
+        {
+          name: "shopify-y",
+          offset: offset,
+          length: PLACEHOLDER.bytesize,
+        },
+      ],
+    }
+  end
+
+  def response_bank_brotli_splice_replacement(slot)
+    shopify_y.ljust(slot.fetch("replacement_length"))
+  end
+
+  def replace_response_bank_brotli_splice_placeholders(body, slots)
+    slots.reduce(body) do |current, slot|
+      replacement = response_bank_brotli_splice_replacement(slot)
+      offset = slot.fetch("html_placeholder_offset")
+      length = slot.fetch("html_placeholder_length")
+
+      current.byteslice(0, offset) + replacement + current.byteslice(offset + length, current.bytesize)
+    end
+  end
+
+  private
+
+  def shopify_y
+    @env.fetch("HTTP_SHOPIFY_Y")
+  end
+end
+```
+
+`prepare_response_bank_brotli_splice` is used on cache writes. It returns HTML containing a neutral placeholder and one slot describing that placeholder. ResponseBank stores the slot metadata with the cached Brotli body.
+
+`response_bank_brotli_splice_replacement` is used on Brotli cache hits. It must return replacement bytes with the same byte length as the stored slot.
+
+`replace_response_bank_brotli_splice_placeholders` is used when a cached Brotli response is decompressed for a client that does not accept Brotli.
+
+Advanced integrations can still install the per-request injector directly in the Rack env before ResponseBank reads or writes the cached body:
+
+```ruby
+env[ResponseBank::BrotliSpliceSlot::INJECTOR_ENV_KEY] = injector
+```
+
 ## License
 
 ResponseBank is released under the [MIT License](LICENSE.txt).

--- a/gemfiles/actionpack_edge.gemfile
+++ b/gemfiles/actionpack_edge.gemfile
@@ -5,4 +5,3 @@ gemspec(path: '..')
 
 gem('rails', github: 'rails/rails', branch: 'main')
 gem('simplecov', require: false, group: :test)
-

--- a/gemfiles/actionpack_edge.gemfile
+++ b/gemfiles/actionpack_edge.gemfile
@@ -5,3 +5,4 @@ gemspec(path: '..')
 
 gem('rails', github: 'rails/rails', branch: 'main')
 gem('simplecov', require: false, group: :test)
+

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'response_bank/brotli_splice_injector'
+require 'response_bank/brotli_splice_slot'
 require 'response_bank/middleware'
 require 'response_bank/railtie' if defined?(Rails)
 require 'response_bank/response_cache_handler'

--- a/lib/response_bank/brotli_splice_injector.rb
+++ b/lib/response_bank/brotli_splice_injector.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module ResponseBank
+  module BrotliSpliceInjector
+    def prepare_response_bank_brotli_splice(body, headers)
+      raise NotImplementedError
+    end
+
+    def response_bank_brotli_splice_replacement(slot)
+      raise NotImplementedError
+    end
+
+    def replace_response_bank_brotli_splice_placeholders(body, slots)
+      raise NotImplementedError
+    end
+  end
+end

--- a/lib/response_bank/brotli_splice_slot.rb
+++ b/lib/response_bank/brotli_splice_slot.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
-require 'brotli_splice'
 
 module ResponseBank
   module BrotliSpliceSlot
     INJECTOR_ENV_KEY = 'response_bank.html_metadata_injector'
     METADATA_KEY = 'brotli_splice'
     METADATA_VERSION = 1
+    # BrotliSplice reserves the last 2 bytes of every slot as a fixed "\r\n" context
+    # suffix, so a slot must be longer than that to hold any replaceable content --
+    # BrotliSplice.encode raises unless the slot length exceeds it.
+    CONTEXT_SUFFIX_LENGTH = 2
 
     EncodedBody = Struct.new(:body, :compressed_body, :metadata, keyword_init: true)
 
@@ -28,52 +31,76 @@ module ResponseBank
         html_length = integer_value(hash_fetch(slot, :length))
         return unless valid_html_slot?(prepared_body, html_offset, html_length)
 
-        result = BrotliSplice.encode(prepared_body, html_offset, html_length, quality: compression_level)
+        # Load the native gem only once we have real splice work to do. Keeping this
+        # outside the begin/rescue below is deliberate: the rescue clause references
+        # BrotliSplice::Error, so if the gem is missing, evaluating that clause would
+        # raise NameError and mask the LoadError we want the caller to see.
+        ensure_brotli_splice_loaded!
 
-        metadata_slot = {
-          'name' => slot_name,
-          'compressed_offset' => result[:secret_offset],
-          'replacement_length' => result[:secret_length],
-          'html_placeholder_offset' => html_offset,
-          'html_placeholder_length' => html_length,
-        }
-        metadata_slot['context_suffix'] = result[:context_suffix] if result[:context_suffix]
+        begin
+          result = BrotliSplice.encode(prepared_body, html_offset, html_length, quality: compression_level)
 
-        EncodedBody.new(
-          body: prepared_body,
-          compressed_body: result[:data],
-          metadata: {
-            METADATA_KEY => {
-              'version' => METADATA_VERSION,
-              'slots' => [metadata_slot],
+          metadata_slot = {
+            'name' => slot_name,
+            'compressed_offset' => result[:secret_offset],
+            'replacement_length' => result[:secret_length],
+            'html_placeholder_offset' => html_offset,
+            'html_placeholder_length' => html_length,
+          }
+          metadata_slot['context_suffix'] = result[:context_suffix] if result[:context_suffix]
+
+          EncodedBody.new(
+            body: prepared_body,
+            compressed_body: result[:data],
+            metadata: {
+              METADATA_KEY => {
+                'version' => METADATA_VERSION,
+                'slots' => [metadata_slot],
+              },
             },
-          },
-        )
-      rescue BrotliSplice::Error, ArgumentError => error
-        ResponseBank.log("BrotliSplice encode skipped: #{error.class}")
-        nil
+          )
+        rescue BrotliSplice::Error, ArgumentError => error
+          ResponseBank.log("BrotliSplice encode skipped: #{error.class}")
+          nil
+        end
       end
 
-      def replace_compressed_body(env, body, metadata)
+      def replace_compressed_secret(env, body, metadata)
         injector = env[INJECTOR_ENV_KEY]
         slots = metadata_slots(metadata)
         return body unless injector && slots && body && body != ''
 
-        slots.reduce(body) do |current_body, slot|
-          replacement = replacement_for_slot(injector, slot)
-          next current_body unless valid_replacement?(replacement, slot)
-          next current_body unless valid_compressed_slot?(current_body, slot)
+        # See encode_body: load outside the begin/rescue so a missing gem surfaces as
+        # LoadError rather than a masked NameError from the BrotliSplice::Error clause.
+        ensure_brotli_splice_loaded!
 
-          BrotliSplice.replace(
-            current_body,
-            replacement,
-            slot['compressed_offset'],
-            slot['replacement_length'],
-          )
+        begin
+          slots.reduce(body) do |current_body, slot|
+            replacement = replacement_for_slot(injector, slot)
+
+            unless valid_replacement?(replacement, slot)
+              got = replacement ? replacement.bytesize : 'nil'
+              ResponseBank.log(
+                'BrotliSplice replace skipped: replacement length mismatch ' \
+                "(got #{got}, want #{slot['replacement_length']})",
+              )
+              next current_body
+            end
+
+            offset = integer_value(slot['compressed_offset'])
+            length = integer_value(slot['replacement_length'])
+
+            unless valid_compressed_slot?(current_body, offset, length)
+              ResponseBank.log('BrotliSplice replace skipped: compressed slot out of bounds')
+              next current_body
+            end
+
+            BrotliSplice.replace(current_body, replacement, offset, length)
+          end
+        rescue BrotliSplice::Error, ArgumentError => error
+          ResponseBank.log("BrotliSplice replace skipped: #{error.class}")
+          body
         end
-      rescue BrotliSplice::Error, ArgumentError => error
-        ResponseBank.log("BrotliSplice replace skipped: #{error.class}")
-        body
       end
 
       def replace_plain_body(env, body, metadata)
@@ -98,6 +125,27 @@ module ResponseBank
 
       private
 
+      # Load the native brotli_splice gem on first use. It is an optional dependency:
+      # apps opt into Brotli splice slots by installing an injector, and only those
+      # apps need the gem. If it is missing when we actually need it, fail loudly with
+      # a pointer to the fix rather than limping along.
+      def ensure_brotli_splice_loaded!
+        return if @brotli_splice_loaded
+
+        begin
+          gem('brotli_splice')
+          require('brotli_splice')
+        rescue LoadError => error
+          warn(
+            'The Brotli splice slot feature requires the "brotli_splice" gem. ' \
+            'Add it to your application Gemfile.',
+          )
+          raise error
+        end
+
+        @brotli_splice_loaded = true
+      end
+
       def replacement_for_slot(injector, slot)
         injector.response_bank_brotli_splice_replacement(slot)
       end
@@ -108,20 +156,16 @@ module ResponseBank
         replacement.bytesize == slot['replacement_length']
       end
 
-      def valid_compressed_slot?(body, slot)
-        offset = integer_value(slot['compressed_offset'])
-        length = integer_value(slot['replacement_length'])
+      def valid_compressed_slot?(body, offset, length)
         return false unless offset && length
         return false unless offset >= 0 && length > 0
 
-        slot['compressed_offset'] = offset
-        slot['replacement_length'] = length
         offset + length <= body.bytesize
       end
 
       def valid_html_slot?(body, offset, length)
         return false unless offset && length
-        return false unless offset >= 0 && length > 0
+        return false unless offset >= 0 && length > CONTEXT_SUFFIX_LENGTH
 
         offset + length <= body.bytesize
       end

--- a/lib/response_bank/brotli_splice_slot.rb
+++ b/lib/response_bank/brotli_splice_slot.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+require 'brotli_splice'
+
+module ResponseBank
+  module BrotliSpliceSlot
+    INJECTOR_ENV_KEY = 'response_bank.html_metadata_injector'
+    METADATA_KEY = 'brotli_splice'
+    METADATA_VERSION = 1
+
+    EncodedBody = Struct.new(:body, :compressed_body, :metadata, keyword_init: true)
+
+    class << self
+      def encode_body(env, body, headers, compression_level:)
+        injector = env[INJECTOR_ENV_KEY]
+        return unless injector
+        return unless body && body != ''
+
+        prepared = injector.prepare_response_bank_brotli_splice(body, headers)
+        return unless prepared
+
+        prepared_body = hash_fetch(prepared, :body)
+        slots = hash_fetch(prepared, :slots)
+        return unless prepared_body && slots && slots.length == 1
+
+        slot = slots.first
+        slot_name = hash_fetch(slot, :name).to_s
+        html_offset = integer_value(hash_fetch(slot, :offset))
+        html_length = integer_value(hash_fetch(slot, :length))
+        return unless valid_html_slot?(prepared_body, html_offset, html_length)
+
+        result = BrotliSplice.encode(prepared_body, html_offset, html_length, quality: compression_level)
+
+        metadata_slot = {
+          'name' => slot_name,
+          'compressed_offset' => result[:secret_offset],
+          'replacement_length' => result[:secret_length],
+          'html_placeholder_offset' => html_offset,
+          'html_placeholder_length' => html_length,
+        }
+        metadata_slot['context_suffix'] = result[:context_suffix] if result[:context_suffix]
+
+        EncodedBody.new(
+          body: prepared_body,
+          compressed_body: result[:data],
+          metadata: {
+            METADATA_KEY => {
+              'version' => METADATA_VERSION,
+              'slots' => [metadata_slot],
+            },
+          },
+        )
+      rescue BrotliSplice::Error, ArgumentError => error
+        ResponseBank.log("BrotliSplice encode skipped: #{error.class}")
+        nil
+      end
+
+      def replace_compressed_body(env, body, metadata)
+        injector = env[INJECTOR_ENV_KEY]
+        slots = metadata_slots(metadata)
+        return body unless injector && slots && body && body != ''
+
+        slots.reduce(body) do |current_body, slot|
+          replacement = replacement_for_slot(injector, slot)
+          next current_body unless valid_replacement?(replacement, slot)
+          next current_body unless valid_compressed_slot?(current_body, slot)
+
+          BrotliSplice.replace(
+            current_body,
+            replacement,
+            slot['compressed_offset'],
+            slot['replacement_length'],
+          )
+        end
+      rescue BrotliSplice::Error, ArgumentError => error
+        ResponseBank.log("BrotliSplice replace skipped: #{error.class}")
+        body
+      end
+
+      def replace_plain_body(env, body, metadata)
+        injector = env[INJECTOR_ENV_KEY]
+        slots = metadata_slots(metadata)
+        return body unless injector && slots && body && body != ''
+
+        injector.replace_response_bank_brotli_splice_placeholders(body, slots)
+      rescue ArgumentError => error
+        ResponseBank.log("BrotliSplice plain replacement skipped: #{error.class}")
+        body
+      end
+
+      def metadata_slots(metadata)
+        return unless metadata
+
+        brotli_splice = metadata[METADATA_KEY]
+        return unless brotli_splice && brotli_splice['version'] == METADATA_VERSION
+
+        brotli_splice['slots']
+      end
+
+      private
+
+      def replacement_for_slot(injector, slot)
+        injector.response_bank_brotli_splice_replacement(slot)
+      end
+
+      def valid_replacement?(replacement, slot)
+        return false unless replacement
+
+        replacement.bytesize == slot['replacement_length']
+      end
+
+      def valid_compressed_slot?(body, slot)
+        offset = integer_value(slot['compressed_offset'])
+        length = integer_value(slot['replacement_length'])
+        return false unless offset && length
+        return false unless offset >= 0 && length > 0
+
+        slot['compressed_offset'] = offset
+        slot['replacement_length'] = length
+        offset + length <= body.bytesize
+      end
+
+      def valid_html_slot?(body, offset, length)
+        return false unless offset && length
+        return false unless offset >= 0 && length > 0
+
+        offset + length <= body.bytesize
+      end
+
+      def integer_value(value)
+        Integer(value)
+      rescue ArgumentError, TypeError
+        nil
+      end
+
+      def hash_fetch(hash, key)
+        hash[key] || hash[key.to_s]
+      end
+    end
+  end
+end

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'response_bank/brotli_splice_slot'
 
 module ResponseBank
   class Middleware
@@ -10,12 +11,15 @@ module ResponseBank
     ACCEPT = "HTTP_ACCEPT"
     USER_AGENT = "HTTP_USER_AGENT"
 
-    def initialize(app)
+    def initialize(app, brotli_splice_injector = nil)
       @app = app
+      @brotli_splice_injector = brotli_splice_injector
     end
 
     def call(env)
       env['cacheable.cache'] = false
+      install_brotli_splice_injector(env)
+
       content_encoding = env['response_bank.server_cache_encoding'] = ResponseBank.check_encoding(env)
 
       status, headers, body = @app.call(env)
@@ -35,15 +39,31 @@ module ResponseBank
           end
 
           body_compressed = nil
+          metadata = nil
           if body_string && body_string != ""
             headers['Content-Encoding'] = content_encoding
             env["cacheable.compression_level"] = ResponseBank.compression_level_for_request(env, headers)
             time = ResponseBank.measure do
-              body_compressed = ResponseBank.compress(
-                body_string,
-                content_encoding,
-                compression_level: env["cacheable.compression_level"],
-              )
+              encoded_body = if content_encoding == 'br'
+                ResponseBank::BrotliSpliceSlot.encode_body(
+                  env,
+                  body_string,
+                  headers,
+                  compression_level: env["cacheable.compression_level"],
+                )
+              end
+
+              if encoded_body
+                body_string = encoded_body.body
+                body_compressed = encoded_body.compressed_body
+                metadata = encoded_body.metadata
+              else
+                body_compressed = ResponseBank.compress(
+                  body_string,
+                  content_encoding,
+                  compression_level: env["cacheable.compression_level"],
+                )
+              end
             end
             ResponseBank.log("Compression time: #{time}ms")
             env["cacheable.compression_time"] = time
@@ -52,6 +72,7 @@ module ResponseBank
           cached_headers = headers.slice(*CACHEABLE_HEADERS)
           # Store result
           cache_data = [status, cached_headers, body_compressed, timestamp, env["cacheable.compression_level"]]
+          cache_data << metadata if metadata
 
           ResponseBank.write_to_cache(env['cacheable.key']) do
             payload = MessagePack.dump(cache_data)
@@ -67,10 +88,15 @@ module ResponseBank
           # as well serve it if the client wants it
           if body_compressed
             if env['HTTP_ACCEPT_ENCODING'].to_s.include?(content_encoding)
-              body = [body_compressed]
+              if content_encoding == 'br'
+                body = [ResponseBank::BrotliSpliceSlot.replace_compressed_body(env, body_compressed, metadata)]
+              else
+                body = [body_compressed]
+              end
             else
               # Remove content-encoding header for response with compressed content
               headers.delete('Content-Encoding')
+              body = [ResponseBank::BrotliSpliceSlot.replace_plain_body(env, body_string, metadata)] if metadata
             end
           end
         end
@@ -86,6 +112,19 @@ module ResponseBank
     end
 
     private
+
+    def install_brotli_splice_injector(env)
+      return unless @brotli_splice_injector
+      return if env.key?(ResponseBank::BrotliSpliceSlot::INJECTOR_ENV_KEY)
+
+      injector = if @brotli_splice_injector.respond_to?(:call)
+        @brotli_splice_injector.call(env)
+      else
+        @brotli_splice_injector
+      end
+
+      env[ResponseBank::BrotliSpliceSlot::INJECTOR_ENV_KEY] = injector if injector
+    end
 
     def timestamp
       Time.now.to_i

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -89,7 +89,7 @@ module ResponseBank
           if body_compressed
             if env['HTTP_ACCEPT_ENCODING'].to_s.include?(content_encoding)
               if content_encoding == 'br'
-                body = [ResponseBank::BrotliSpliceSlot.replace_compressed_body(env, body_compressed, metadata)]
+                body = [ResponseBank::BrotliSpliceSlot.replace_compressed_secret(env, body_compressed, metadata)]
               else
                 body = [body_compressed]
               end

--- a/lib/response_bank/railtie.rb
+++ b/lib/response_bank/railtie.rb
@@ -1,12 +1,20 @@
 # frozen_string_literal: true
 require 'rails'
+require 'active_support/ordered_options'
 require 'response_bank/controller'
 require 'response_bank/model_extensions'
 
 module ResponseBank
   class Railtie < ::Rails::Railtie
-    initializer "cachable.configure_active_record" do |config|
-      config.middleware.insert_after(Rack::Head, ResponseBank::Middleware)
+    config.response_bank = ActiveSupport::OrderedOptions.new
+    config.response_bank.brotli_splice_injector = nil
+
+    initializer "cachable.configure_active_record" do |app|
+      app.config.middleware.insert_after(
+        Rack::Head,
+        ResponseBank::Middleware,
+        app.config.response_bank.brotli_splice_injector,
+      )
 
       ActiveSupport.on_load(:action_controller) do
         include ResponseBank::Controller

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'digest/md5'
+require 'response_bank/brotli_splice_slot'
 
 module ResponseBank
   class ResponseCacheHandler
@@ -119,7 +120,7 @@ module ResponseBank
         @env['cacheable.miss']  = false
         @env['cacheable.store'] = 'server'
 
-        status, headers, body, timestamp, compression_level = hit
+        status, headers, body, timestamp, compression_level, metadata = hit
 
         @env['cacheable.compression_level'] = compression_level
 
@@ -152,9 +153,14 @@ module ResponseBank
         @headers.merge!(headers)
 
         if @headers['Content-Encoding']
-          if !@env['HTTP_ACCEPT_ENCODING'].to_s.include?(@headers['Content-Encoding'])
+          if @env['HTTP_ACCEPT_ENCODING'].to_s.include?(@headers['Content-Encoding'])
+            if @headers['Content-Encoding'] == 'br'
+              body = ResponseBank::BrotliSpliceSlot.replace_compressed_body(@env, body, metadata)
+            end
+          else
             ResponseBank.log("uncompressing payload for client as client doesn't require encoding")
             body = ResponseBank.decompress(body, @headers['Content-Encoding'])
+            body = ResponseBank::BrotliSpliceSlot.replace_plain_body(@env, body, metadata)
             @headers.delete('Content-Encoding')
           end
         else
@@ -182,7 +188,7 @@ module ResponseBank
       # to avoid unintended greedy matches in we check for naked entity then includes with quoted entity values
       entity_tag = %{"#{entity_tag}"} unless entity_tag.starts_with?('"')
 
-      if_none_match = %{"#{if_none_match}"} unless if_none_match.starts_with?('"') || if_none_match.starts_with?('W/"')
+      if_none_match = %{"#{if_none_match}"} unless if_none_match.start_with?('"') || if_none_match.start_with?('W/"')
 
       if_none_match == entity_tag || if_none_match.include?(entity_tag)
     end

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -155,7 +155,7 @@ module ResponseBank
         if @headers['Content-Encoding']
           if @env['HTTP_ACCEPT_ENCODING'].to_s.include?(@headers['Content-Encoding'])
             if @headers['Content-Encoding'] == 'br'
-              body = ResponseBank::BrotliSpliceSlot.replace_compressed_body(@env, body, metadata)
+              body = ResponseBank::BrotliSpliceSlot.replace_compressed_secret(@env, body, metadata)
             end
           else
             ResponseBank.log("uncompressing payload for client as client doesn't require encoding")
@@ -186,7 +186,7 @@ module ResponseBank
 
       # strictly speaking an unquoted etag is not valid, yet common
       # to avoid unintended greedy matches in we check for naked entity then includes with quoted entity values
-      entity_tag = %{"#{entity_tag}"} unless entity_tag.starts_with?('"')
+      entity_tag = %{"#{entity_tag}"} unless entity_tag.start_with?('"')
 
       if_none_match = %{"#{if_none_match}"} unless if_none_match.start_with?('"') || if_none_match.start_with?('W/"')
 

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -21,7 +21,13 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("msgpack")
   s.add_runtime_dependency("brotli")
-  s.add_runtime_dependency("brotli_splice")
+
+  # brotli_splice is optional for consumers: only apps that opt into Brotli splice
+  # slots need this native extension, so it is not a runtime dependency (they add it
+  # to their own Gemfile -- see README). It is a development dependency here so the
+  # gem's own test suite, which exercises the splice path directly, can load it --
+  # including the actionpack matrix gemfiles in CI, which inherit it through gemspec.
+  s.add_development_dependency("brotli_splice", "= 0.1.1")
 
   s.add_development_dependency("minitest")
   s.add_development_dependency("mocha")

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("msgpack")
   s.add_runtime_dependency("brotli")
+  s.add_runtime_dependency("brotli_splice")
 
   s.add_development_dependency("minitest")
   s.add_development_dependency("mocha")

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -132,6 +132,54 @@ def client_hit_app(env)
   [304, { 'Content-Type' => 'text/plain' }, body]
 end
 
+# An injector that addresses the slot by byte offset/length (like the README example
+# and the real storefront injector), so it can splice the replacement into the
+# *uncompressed* body served on the miss -> plain-body branch. The string-substitution
+# HtmlMetadataInjector in test_helper only matches once the Brotli body is decompressed.
+class OffsetHtmlMetadataInjector
+  include ResponseBank::BrotliSpliceInjector
+
+  CONTEXT_SUFFIX = "\r\n"
+
+  def initialize(placeholder:, replacement:)
+    @placeholder = placeholder
+    @replacement = replacement
+  end
+
+  def prepare_response_bank_brotli_splice(body, _headers)
+    tag = %(<meta name="shopify-y" content="#{@placeholder}#{CONTEXT_SUFFIX}">)
+    html = body.sub('</head>', "#{tag}</head>")
+    offset = html.b.index(@placeholder)
+
+    {
+      body: html,
+      slots: [
+        {
+          name: 'shopify_y',
+          offset: offset,
+          length: @placeholder.bytesize + CONTEXT_SUFFIX.bytesize,
+        },
+      ],
+    }
+  end
+
+  def response_bank_brotli_splice_replacement(slot)
+    @replacement if @replacement.bytesize == slot.fetch('replacement_length')
+  end
+
+  def replace_response_bank_brotli_splice_placeholders(body, slots)
+    slots.reduce(body) do |current, slot|
+      replacement = response_bank_brotli_splice_replacement(slot)
+      next current unless replacement
+
+      offset = slot.fetch('html_placeholder_offset')
+      length = slot.fetch('html_placeholder_length')
+      suffix = slot.fetch('context_suffix', CONTEXT_SUFFIX)
+      current.byteslice(0, offset) + replacement + suffix + current.byteslice(offset + length, current.bytesize)
+    end
+  end
+end
+
 class MiddlewareTest < Minitest::Test
   def setup
     @original_cache_store = ResponseBank.cache_store
@@ -445,6 +493,40 @@ class MiddlewareTest < Minitest::Test
 
     decoded_served_body = Brotli.inflate(result[2].first)
     assert_includes(decoded_served_body, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+  end
+
+  def test_cache_miss_with_injector_serves_spliced_plain_body_to_client_without_br
+    ResponseBank::Middleware.any_instance.stubs(timestamp: 424242)
+    @env['HTTP_ACCEPT_ENCODING'] = 'deflate, pkzip' # accepts neither br nor gzip
+
+    injector = OffsetHtmlMetadataInjector.new(
+      placeholder: '00000000-0000-0000-0000-000000000000',
+      replacement: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    )
+
+    ware = ResponseBank::Middleware.new(method(:cacheable_html_app), ->(_env) { injector })
+    result = ware.call(@env)
+    headers = result[1]
+    served_body = result[2].first
+
+    # The server still Brotli-encodes for its cache -- check_encoding defaults to 'br'
+    # even though this client accepts neither br nor gzip -- and stores the neutral
+    # placeholder plus the slot metadata.
+    captured_payload = MessagePack.load(ResponseBank.cache_store.read('cacheable_html_app_cache_key', raw: true))
+    _status, cached_headers, cached_body, _timestamp, _compression_level, metadata = captured_payload
+    assert_equal('br', cached_headers['Content-Encoding'])
+    assert(metadata, 'expected brotli_splice metadata to be cached')
+    assert_includes(Brotli.inflate(cached_body), '00000000-0000-0000-0000-000000000000')
+
+    # Because the client cannot accept br, the middleware takes the
+    # `replace_plain_body(...) if metadata` branch (reachable -- not dead code): it
+    # serves an uncompressed body with the per-request value spliced in and drops
+    # Content-Encoding.
+    assert_nil(headers['Content-Encoding'])
+    assert_equal('miss', headers['X-Cache'])
+    assert_includes(served_body, '<body>Hi</body>')
+    assert_includes(served_body, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+    refute_includes(served_body, '00000000-0000-0000-0000-000000000000')
   end
 
   def test_configured_brotli_splice_injector_is_installed_before_app_call

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -81,6 +81,15 @@ def cacheable_app_with_long_response(env)
   [200, { 'Content-Type' => 'text/plain' }, body]
 end
 
+def cacheable_html_app(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss']  = true
+  env['cacheable.key']   = 'etag_value'
+  env['cacheable.unversioned-key'] = 'cacheable_html_app_cache_key'
+
+  [200, { 'Content-Type' => 'text/html' }, ['<html><head></head><body>Hi</body></html>']]
+end
+
 def cacheable_app_limit_headers(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = true
@@ -403,6 +412,70 @@ class MiddlewareTest < Minitest::Test
     # gzip support!
     assert_equal('br', headers['Content-Encoding'])
     assert_equal([ResponseBank.compress("Hi", 'br')], result[2])
+  end
+
+  def test_cache_miss_uses_brotli_splice_when_injector_returns_slot
+    ResponseBank::Middleware.any_instance.stubs(timestamp: 424242)
+    injector = HtmlMetadataInjector.new(
+      placeholder: '00000000-0000-0000-0000-000000000000',
+      replacement: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    )
+
+    ware = ResponseBank::Middleware.new(method(:cacheable_html_app), ->(_env) { injector })
+    result = ware.call(@env)
+    headers = result[1]
+
+    captured_payload = MessagePack.load(ResponseBank.cache_store.read('cacheable_html_app_cache_key', raw: true))
+    status, cached_headers, cached_body, timestamp, compression_level, metadata = captured_payload
+    slot = metadata.fetch('brotli_splice').fetch('slots').first
+
+    assert_equal(200, status)
+    assert_equal({'Content-Type' => 'text/html', 'ETag' => '"etag_value"', 'Content-Encoding' => 'br'}, cached_headers)
+    assert_equal(424242, timestamp)
+    assert_equal(7, compression_level)
+    assert_equal('shopify_y', slot['name'])
+    assert_equal(36, slot['replacement_length'])
+    assert_equal(38, slot['html_placeholder_length'])
+    assert_equal('br', headers['Content-Encoding'])
+    assert_equal('miss', headers['X-Cache'])
+
+    decoded_cached_body = Brotli.inflate(cached_body)
+    assert_includes(decoded_cached_body, '00000000-0000-0000-0000-000000000000')
+    refute_includes(decoded_cached_body, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+    decoded_served_body = Brotli.inflate(result[2].first)
+    assert_includes(decoded_served_body, 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+  end
+
+  def test_configured_brotli_splice_injector_is_installed_before_app_call
+    injector = HtmlMetadataInjector.new(
+      placeholder: '00000000-0000-0000-0000-000000000000',
+      replacement: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    )
+    app = lambda do |env|
+      assert_same(injector, env.fetch(ResponseBank::BrotliSpliceSlot::INJECTOR_ENV_KEY))
+      cacheable_html_app(env)
+    end
+
+    ware = ResponseBank::Middleware.new(app, ->(_env) { injector })
+
+    ware.call(@env)
+  end
+
+  def test_cache_miss_falls_back_to_standard_brotli_when_no_injector
+    ResponseBank::Middleware.any_instance.stubs(timestamp: 424242)
+    ResponseBank.cache_store.expects(:write).with(
+      'cacheable_html_app_cache_key',
+      MessagePack.dump([200, {'Content-Type' => 'text/html', 'ETag' => '"etag_value"', 'Content-Encoding' => 'br'}, ResponseBank.compress('<html><head></head><body>Hi</body></html>', 'br'), 424242, 7]),
+      raw: true,
+      expires_in: nil,
+    ).once
+
+    ware = ResponseBank::Middleware.new(method(:cacheable_html_app))
+    result = ware.call(@env)
+
+    assert_equal('br', result[1]['Content-Encoding'])
+    assert_equal([ResponseBank.compress('<html><head></head><body>Hi</body></html>', 'br')], result[2])
   end
 
   def test_cache_hit_server

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -39,6 +39,37 @@ class ResponseCacheHandlerTest < Minitest::Test
     MessagePack.dump(page(cache_hit, compression))
   end
 
+  def spliced_page_cache_entry(cache_hit = true)
+    etag = cache_hit ? handler.entity_tag_hash : "not-cached"
+    html = '<html><head><meta name="shopify-y" content="00000000-0000-0000-0000-000000000000##"></head><body>cached output</body></html>'
+    placeholder_offset = html.index('00000000-0000-0000-0000-000000000000')
+    result = BrotliSplice.encode(html, placeholder_offset, 38, quality: 7)
+    metadata = {
+      'brotli_splice' => {
+        'version' => 1,
+        'slots' => [
+          {
+            'name' => 'shopify_y',
+            'compressed_offset' => result[:secret_offset],
+            'replacement_length' => result[:secret_length],
+            'html_placeholder_offset' => placeholder_offset,
+            'html_placeholder_length' => 38,
+            'context_suffix' => result[:context_suffix],
+          },
+        ],
+      },
+    }
+
+    MessagePack.dump([
+      200,
+      {"Content-Type" => "text/html", "ETag" => %{"#{etag}"}, "Content-Encoding" => 'br'},
+      result[:data],
+      1331765506,
+      7,
+      metadata,
+    ])
+  end
+
   def page_uncompressed(cache_hit = true)
     etag = cache_hit ? handler.entity_tag_hash : "not-cached"
     [200, {"Content-Type" => "text/html", "ETag" => %{"#{etag}"}}, "<body>cached output</body>", 1331765506]
@@ -168,6 +199,58 @@ class ResponseCacheHandlerTest < Minitest::Test
     assert_equal(_headers['Content-Type'], headers["Content-Type"])
     assert_nil(headers["Content-Encoding"])
     assert_equal(9, controller.request.env['cacheable.compression_level'])
+    assert_cache_miss(false, 'server')
+  end
+
+  def test_server_cache_hit_replaces_brotli_splice_slot_for_brotli_client
+    controller.request.env['HTTP_ACCEPT_ENCODING'] = 'br'
+    controller.request.env[ResponseBank::BrotliSpliceSlot::INJECTOR_ENV_KEY] = HtmlMetadataInjector.new(
+      placeholder: '00000000-0000-0000-0000-000000000000',
+      replacement: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    )
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(spliced_page_cache_entry)
+
+    status, headers, body = handler.run!
+    decoded_body = Brotli.inflate(body.first)
+
+    assert_equal(200, status)
+    assert_equal('br', headers['Content-Encoding'])
+    assert_includes(decoded_body, 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+    refute_includes(decoded_body, '00000000-0000-0000-0000-000000000000')
+    assert_cache_miss(false, 'server')
+  end
+
+  def test_server_cache_hit_replaces_plain_placeholder_for_non_brotli_client
+    controller.request.env['HTTP_ACCEPT_ENCODING'] = 'gzip'
+    controller.request.env[ResponseBank::BrotliSpliceSlot::INJECTOR_ENV_KEY] = HtmlMetadataInjector.new(
+      placeholder: '00000000-0000-0000-0000-000000000000',
+      replacement: 'cccccccc-cccc-cccc-cccc-cccccccccccc',
+    )
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(spliced_page_cache_entry)
+
+    status, headers, body = handler.run!
+
+    assert_equal(200, status)
+    assert_nil(headers['Content-Encoding'])
+    assert_includes(body.first, 'cccccccc-cccc-cccc-cccc-cccccccccccc')
+    refute_includes(body.first, '00000000-0000-0000-0000-000000000000')
+    assert_cache_miss(false, 'server')
+  end
+
+  def test_server_cache_hit_serves_cached_body_when_replacement_length_mismatches
+    controller.request.env['HTTP_ACCEPT_ENCODING'] = 'br'
+    controller.request.env[ResponseBank::BrotliSpliceSlot::INJECTOR_ENV_KEY] = HtmlMetadataInjector.new(
+      placeholder: '00000000-0000-0000-0000-000000000000',
+      replacement: 'too-short',
+    )
+    @cache_store.expects(:read).with(handler.cache_key_hash, raw: true).returns(spliced_page_cache_entry)
+
+    _status, headers, body = handler.run!
+    decoded_body = Brotli.inflate(body.first)
+
+    assert_equal('br', headers['Content-Encoding'])
+    assert_includes(decoded_body, '00000000-0000-0000-0000-000000000000')
+    refute_includes(decoded_body, 'too-short')
     assert_cache_miss(false, 'server')
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,45 @@ require 'response_bank'
 
 ResponseBank.logger = Class.new { def info(a); end }.new
 
+class HtmlMetadataInjector
+  include ResponseBank::BrotliSpliceInjector
+
+  PLACEHOLDER_SUFFIX = "##"
+
+  attr_reader :placeholder, :replacement
+
+  def initialize(placeholder:, replacement:)
+    @placeholder = placeholder
+    @replacement = replacement
+  end
+
+  def prepare_response_bank_brotli_splice(body, _headers)
+    tag = %(<meta name="shopify-y" content="#{placeholder}#{PLACEHOLDER_SUFFIX}">)
+    html = body.sub('</head>', "#{tag}</head>")
+    offset = html.index(placeholder)
+
+    {
+      body: html,
+      slots: [
+        {
+          name: 'shopify_y',
+          offset: offset,
+          length: placeholder.bytesize + PLACEHOLDER_SUFFIX.bytesize,
+        },
+      ],
+    }
+  end
+
+  def response_bank_brotli_splice_replacement(_slot)
+    replacement
+  end
+
+  def replace_response_bank_brotli_splice_placeholders(body, slots)
+    suffix = slots.first['context_suffix'] || PLACEHOLDER_SUFFIX
+    body.sub("#{placeholder}#{suffix}", "#{replacement}#{suffix}")
+  end
+end
+
 class MockController < ActionController::Base
   def self.after_filter(*args); end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,6 +12,10 @@ require 'action_controller/railtie'
 require 'mocha/minitest'
 
 require 'response_bank'
+# response_bank now loads the native brotli_splice gem lazily (only when an app opts
+# into splice slots). The test suite exercises that feature directly -- e.g. building
+# spliced cache fixtures with BrotliSplice.encode -- so load it explicitly here.
+require 'brotli_splice'
 
 ResponseBank.logger = Class.new { def info(a); end }.new
 


### PR DESCRIPTION
## Summary

Adds opt-in BrotliSplice slot handling for cached Brotli HTML responses, so a small per-request secret (e.g. a nonce or a `shopify_y`-style token) can be spliced into an otherwise fully-cached, pre-compressed Brotli body without recompressing it.

- Add BrotliSplice slot handling for cached Brotli HTML responses.
- Store splice slot metadata on cache writes and replace slot contents on cache hits.
- Add `ResponseBank::BrotliSpliceInjector` as the documented injector contract.
- Allow Rack apps to pass an injector builder directly to `ResponseBank::Middleware`.
- Allow Rails apps to configure the same builder with `config.response_bank.brotli_splice_injector`.
- Keep concrete metadata extraction in the application layer; ResponseBank owns only the generic Brotli splice hook and middleware wiring.
- Keep the Rack env injector key as an advanced compatibility hook.
- **`brotli_splice` is an _optional_ dependency.** It is a native C extension and only apps that opt into splice slots need it, so it is **not a runtime dependency** — consuming apps add `gem "brotli_splice"` to their own Gemfile and ResponseBank loads it lazily on first use (see _Review fixes_ below). It is declared as a **development dependency** in the gemspec so the gem can test the splice path itself; the CI matrix gemfiles inherit it through `gemspec` exactly as they do `minitest`/`rake`. The ordinary `brotli` compression gem stays a hard runtime dependency.
- Install Ubuntu `libbrotli-dev` in CI so the `brotli_splice` native extension can compile for the gem's own test suite.

## Usage shape

```ruby
use ResponseBank::Middleware, ->(env) { HtmlMetadataInjector.new(env) }
```

```ruby
config.response_bank.brotli_splice_injector =
  ->(env) { HtmlMetadataInjector.new(env) }
```

The consumer app owns `HtmlMetadataInjector` and may include `ResponseBank::BrotliSpliceInjector` to document the required methods. To enable the feature the consumer app must also add `gem "brotli_splice"` to its Gemfile.

## Review fixes

The second commit addresses review feedback and hardens edge cases:

- **README example correctness.** The documented injector reserved the wrong slot length and returned a replacement padded to the full slot width. Because BrotliSplice reserves the last 2 bytes of each slot as a fixed `\r\n` context suffix, the replacement never matched `replacement_length`, so `valid_replacement?` failed and every Brotli cache hit silently served the neutral placeholder. The example now reserves those 2 bytes and returns a replacement of exactly `replacement_length`, and documents that slot offset/length are byte offsets/counts (a character offset passes the bounds check but points at the wrong place once multi-byte UTF-8 precedes the placeholder).
- **Optional dependency + lazy load** (per review): in the gemspec `brotli_splice` moved from a runtime to a **development** dependency, so consumers no longer build the native extension, while the gem's own CI (the actionpack matrix gemfiles) still gets it through `gemspec`. At runtime it is loaded through a memoized `ensure_brotli_splice_loaded!` (`gem` + `require`, `rescue LoadError → warn + raise`) called at the top of the two methods that touch the native extension (`encode_body`, `replace_compressed_secret`). Apps without an injector never trigger the `require`; an opted-in app that forgot the gem fails loudly with a Gemfile hint. The loader deliberately sits **outside** the `rescue BrotliSplice::Error` block, so a missing gem surfaces as `LoadError` rather than a `NameError` from Ruby evaluating that (undefined) rescue constant.
- **Cover the miss → plain-body branch.** When a client accepts neither `br` nor `gzip`, `check_encoding` still defaults to `br`, so a cache miss with an injector produces Brotli metadata but must be served uncompressed via `replace_plain_body`. Added a middleware test (with a byte-offset injector) proving that branch is reached and splices the per-request value into the plain body — it is reachable, not dead code.
- **`valid_compressed_slot?` is now a pure predicate.** It previously coerced offset/length to integers and wrote them back into the slot hash; coercion moved to the caller, which passes locals to both the predicate and `BrotliSplice.replace` (behavior byte-for-byte identical).
- **`valid_html_slot?` rejects slots no larger than the 2-byte context suffix**, which have no replaceable region and would otherwise raise inside `BrotliSplice.encode`.
- **Observability:** log when `replace_compressed_secret` skips a slot (length mismatch / compressed slot out of bounds), mirroring the existing skip logs.
- Renamed `replace_compressed_body` → `replace_compressed_secret`; made `etag_matches?` use `start_with?` for the entity tag; aligned the README slot name to `shopify_y`; restored a trailing blank line in `gemfiles/actionpack_edge.gemfile`.

## Testing

- `ruby -c` passes for every changed Ruby file.
- Full suite, run in a Ruby 3.4 env with `libbrotli` + the `brotli_splice` extension available:

  ```bash
  bundle exec ruby -I. test/middleware_test.rb
  bundle exec rake test
  ```

  > The second commit adds `test_cache_miss_with_injector_serves_spliced_plain_body_to_client_without_br` plus the edge cases above, so run counts are higher than the original feature-commit run (previously middleware_test.rb: 19 runs / 101 assertions; full suite: 61 runs / 320 assertions). Final counts are confirmed by CI.
