### PR TITLE
Bump version to 1.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.3.8] - 2026-07-10
+
+### Added
+- Brotli splice cache slot handling: reserve fixed-length slots in a
+  Brotli-compressed cached response body and splice per-request values into them
+  at serve time, without recompressing the body ([#103]).
+- `brotli_splice` as a dependency, powering the splice slot support ([#102]).
+
+Releases prior to 1.3.8 are recorded in the project's git tags and GitHub Releases.
+
+[1.3.8]: https://github.com/Shopify/response_bank/releases/tag/v1.3.8
+[#102]: https://github.com/Shopify/response_bank/pull/102
+[#103]: https://github.com/Shopify/response_bank/pull/103

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    response_bank (1.3.7)
+    response_bank (1.3.8)
       brotli
       brotli_splice
       msgpack

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ResponseBank
-  VERSION = "1.3.7"
+  VERSION = "1.3.8"
 end


### PR DESCRIPTION
Bumps `response_bank` from 1.3.7 to 1.3.8.

### What's new since 1.3.7
- **Brotli splice cache slot handling** — reserve fixed-length slots in a Brotli-compressed cached response body and splice per-request values into them at serve time, without recompressing the body (#103).
- Adds the `brotli_splice` dependency that powers it (#102).

### Changes in this PR
- `lib/response_bank/version.rb` — `VERSION` 1.3.7 → 1.3.8
- `Gemfile.lock` — `response_bank` self-reference 1.3.7 → 1.3.8
- `CHANGELOG.md` — new file (Keep a Changelog format) with the 1.3.8 entry

### Why
Cutting 1.3.8 so Storefront Renderer can depend on a tagged release of the Brotli splice feature (shop/world PR #910569) instead of pinning a branch SHA.

Intended follow-up after merge: tag `v1.3.8` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
