### PR TITLE
Require Ruby 3.1 or newer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     response_bank (1.3.8)
       brotli
-      brotli_splice
       msgpack
 
 GEM

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This gem supports the following versions of Ruby and Rails:
 
-* Ruby 2.7.0+
+* Ruby 3.1.0+
 * Rails 6.0.0+
 
 ## Usage

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files         = Dir["lib/**/*.rb", "README.md", "LICENSE.txt"]
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = ">= 2.7.0"
+  s.required_ruby_version = ">= 3.1.0"
 
   s.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
## Summary

- raise the minimum supported Ruby version from 2.7 to 3.1
- update the documented Ruby requirement
- refresh the lockfile so `brotli_splice` remains a direct development dependency rather than appearing under `response_bank`'s runtime dependencies

## Why

Dependabot resolves updates against the lowest Ruby version allowed by a gem's `required_ruby_version`. It currently selects Ruby 2.7.8, which cannot resolve `brotli_splice` 0.1.1 because that gem requires Ruby 3.1 or newer.

Ruby 3.1 also matches the minimum requirement of Rails 7.2, the oldest Rails version in the current CI matrix.

## Testing

- `bundle exec rake test` — 62 runs, 332 assertions, 0 failures
- built the gem and verified `required_ruby_version` is `>= 3.1.0`
- [GitHub Actions](https://github.com/Shopify/response_bank/actions/runs/29121298987)
