### PR TITLE
Add one-shot deferred cache fills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Cache writes build a separate cached-header hash instead of adding
+  `Content-Encoding` to the caller's live headers ([#112]).
+
 ## [1.3.8] - 2026-07-10
 
 ### Added
@@ -18,3 +24,4 @@ Releases prior to 1.3.8 are recorded in the project's git tags and GitHub Releas
 [1.3.8]: https://github.com/Shopify/response_bank/releases/tag/v1.3.8
 [#102]: https://github.com/Shopify/response_bank/pull/102
 [#103]: https://github.com/Shopify/response_bank/pull/103
+[#112]: https://github.com/Shopify/response_bank/pull/112

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- `ResponseBank.defer_store`, which returns a one-shot handle for completing or
+  aborting a cache miss after the Rack tuple returns ([#112]).
+- `ResponseBank.release_lock`, an optional hook used when an abandoned deferred
+  fill must release its lock ([#112]).
+- `ResponseBank::CACHEABLE_STATUSES`, the gem's storage policy, with the existing
+  middleware constant retained as an alias ([#112]).
+
 ### Changed
+- Deferred responses do not emit a live ETag. A successful completion adds the
+  ETag only to the cached representation ([#112]).
 - Cache writes build a separate cached-header hash instead of adding
   `Content-Encoding` to the caller's live headers ([#112]).
+- Deferred completion requires logical fill-lock ownership recorded by
+  `ResponseCacheHandler` ([#112]).
 
 ## [1.3.8] - 2026-07-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Content-Encoding` to the caller's live headers ([#112]).
 - Deferred completion requires logical fill-lock ownership recorded by
   `ResponseCacheHandler` ([#112]).
+- A one-element Rack body holding a String is no longer copied before it is
+  compressed. An Array subclass keeps the enumeration path, because it may
+  override `each` ([#112]).
 
 ## [1.3.8] - 2026-07-10
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,32 @@ This gem supports the following versions of Ruby and Rails:
     end
     ```
 
+## Completing a deferred cache miss
+
+`ResponseBank::Middleware` can cache a body only when it is complete before the Rack tuple returns. An application that finishes a response later, such as through Rack partial hijack, can defer the cache write during a real ResponseBank miss:
+
+```ruby
+deferred_store = ResponseBank.defer_store(env)
+
+# Return the Rack response. Later, after the body was generated and written in full:
+cache_headers = headers.dup
+cache_headers.delete('Cache-Control') if cache_headers['Cache-Control'] == 'no-cache, no-store'
+deferred_store.complete(headers: cache_headers, body: completed_body)
+
+# Run this from the response-finished path. It is a no-op after completion.
+deferred_store.abort
+```
+
+`defer_store` is a cache-fill lifecycle API. Call it only from a ResponseBank cache-miss path after `ResponseCacheHandler` initialized the request and recorded logical fill-lock ownership. It raises if the request is not a GET cache miss, if required cache context is absent, or if another deferred store is already registered.
+
+The middleware arms the handle after the application returns the Rack tuple. It does not add an ETag to the live deferred response. `complete` copies and filters the final cache headers, adds the cached ETag and `Content-Encoding`, compresses the complete body, and writes the existing MessagePack cache format. It returns `true` when it stores and `false` when the request no longer owns an eligible fill.
+
+Call `complete` only after the intended response was generated and written successfully. Never call it from a rescue or ensure path. Do not complete failed, timed-out, disconnected, or truncated responses. The body must be the shared cache representation and must not contain client-specific data added for the live response.
+
+The headers passed to `complete` describe the cached representation. They can differ from headers already sent to the client. ResponseBank rejects final cache headers that contain `private` or `no-store`, and it does not mutate the supplied hash. It captures the cache timestamp when `defer_store` is called, before deferred rendering and compression.
+
+`abort` is idempotent and releases an owned fill lock through `ResponseBank.release_lock`. Its default implementation is a no-op. The existing `write_to_cache` hook remains responsible for cleanup after a write attempt. An integration that releases those fills from `write_to_cache` should also implement `release_lock` for abandoned fills and failures that happen before the write hook. A key-only lock cannot prevent an old fill from releasing a replacement lock after its lease expires; integrations that need that guarantee must use owner tokens in their lock implementation.
+
 ## Brotli Splice Slots
 
 Applications that need per-request replacement inside cached Brotli HTML responses can pass an injector builder to `ResponseBank::Middleware`:

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require 'response_bank/brotli_splice_injector'
 require 'response_bank/brotli_splice_slot'
+require 'response_bank/cache_policy'
+require 'response_bank/cache_writer'
 require 'response_bank/middleware'
 require 'response_bank/railtie' if defined?(Rails)
 require 'response_bank/response_cache_handler'
@@ -9,6 +11,8 @@ require 'brotli'
 require 'benchmark'
 
 module ResponseBank
+  private_constant :CacheWriter
+
   class << self
     attr_accessor :cache_store
     attr_writer :logger, :compression_level

--- a/lib/response_bank.rb
+++ b/lib/response_bank.rb
@@ -3,6 +3,7 @@ require 'response_bank/brotli_splice_injector'
 require 'response_bank/brotli_splice_slot'
 require 'response_bank/cache_policy'
 require 'response_bank/cache_writer'
+require 'response_bank/deferred_store'
 require 'response_bank/middleware'
 require 'response_bank/railtie' if defined?(Rails)
 require 'response_bank/response_cache_handler'
@@ -42,6 +43,17 @@ module ResponseBank
 
     def acquire_lock(_cache_key)
       raise NotImplementedError, "Override ResponseBank.acquire_lock in an initializer."
+    end
+
+    # Starts a one-shot deferred cache fill for the current ResponseBank miss.
+    # Complete it only after the intended shared response was generated and
+    # written successfully. Abort failed, disconnected or truncated responses.
+    def defer_store(env, timestamp: Time.now.to_i)
+      DeferredStore.create(env, timestamp: timestamp)
+    end
+
+    # Override when deferred fills must release an application-managed lock.
+    def release_lock(_cache_key)
     end
 
     def write_to_cache(_key)

--- a/lib/response_bank/cache_policy.rb
+++ b/lib/response_bank/cache_policy.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ResponseBank
+  CACHEABLE_HEADERS = ["Location", "Content-Type", "ETag", "Content-Encoding", "Last-Modified", "Cache-Control", "Expires", "Link", "Surrogate-Keys", "Cache-Tags", "Speculation-Rules"].freeze
+  CACHEABLE_STATUSES = [200, 404, 301].freeze
+end

--- a/lib/response_bank/cache_writer.rb
+++ b/lib/response_bank/cache_writer.rb
@@ -10,11 +10,15 @@ module ResponseBank
 
     class << self
       def flatten(body)
-        return body if body.is_a?(String)
-
-        result = +''
-        body.each { |part| result << part }
-        result
+        if body.is_a?(String)
+          body
+        elsif body.instance_of?(Array) && body.size == 1 && body[0].is_a?(String)
+          body[0]
+        else
+          result = +''
+          body.each { |part| result << part }
+          result
+        end
       end
 
       def store(

--- a/lib/response_bank/cache_writer.rb
+++ b/lib/response_bank/cache_writer.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'response_bank/brotli_splice_slot'
+require 'msgpack'
+
+module ResponseBank
+  class CacheWriter
+    Stored = Struct.new(:body, :compressed_body, :metadata, keyword_init: true)
+
+    class << self
+      def flatten(body)
+        return body if body.is_a?(String)
+
+        result = +""
+        body.each { |part| result << part }
+        result
+      end
+
+      def store(env, status:, headers:, body:, timestamp:, content_encoding:, cacheable_headers:, on_prepared: nil)
+        body_compressed = nil
+        metadata = nil
+        if body && body != ""
+          env["cacheable.compression_level"] = ResponseBank.compression_level_for_request(env, headers)
+          time = ResponseBank.measure do
+            encoded_body = if content_encoding == 'br'
+              ResponseBank::BrotliSpliceSlot.encode_body(
+                env,
+                body,
+                headers,
+                compression_level: env["cacheable.compression_level"],
+              )
+            end
+
+            if encoded_body
+              body = encoded_body.body
+              body_compressed = encoded_body.compressed_body
+              metadata = encoded_body.metadata
+            else
+              body_compressed = ResponseBank.compress(
+                body,
+                content_encoding,
+                compression_level: env["cacheable.compression_level"],
+              )
+            end
+          end
+          ResponseBank.log("Compression time: #{time}ms")
+          env["cacheable.compression_time"] = time
+          headers['Content-Encoding'] = content_encoding
+        end
+
+        cached_headers = headers.slice(*cacheable_headers)
+        generated_at = timestamp.respond_to?(:call) ? timestamp.call : timestamp
+        cache_data = [status, cached_headers, body_compressed, generated_at, env["cacheable.compression_level"]]
+        cache_data << metadata if metadata
+
+        stored = Stored.new(body: body, compressed_body: body_compressed, metadata: metadata)
+        on_prepared&.call(stored)
+        ResponseBank.write_to_cache(env['cacheable.key']) do
+          payload = MessagePack.dump(cache_data)
+          ResponseBank.write_to_backing_cache_store(
+            env,
+            env['cacheable.unversioned-key'],
+            payload,
+            expires_in: env['cacheable.versioned-cache-expiry'],
+          )
+        end
+
+        stored
+      end
+    end
+  end
+end

--- a/lib/response_bank/cache_writer.rb
+++ b/lib/response_bank/cache_writer.rb
@@ -17,7 +17,15 @@ module ResponseBank
         result
       end
 
-      def store(env, status:, headers:, body:, timestamp:, content_encoding:)
+      def store(
+        env,
+        status:,
+        headers:,
+        body:,
+        timestamp:,
+        content_encoding: env.fetch('response_bank.server_cache_encoding'),
+        before_write: nil
+      )
         cache_key = env.fetch('cacheable.key')
         unversioned_key = env.fetch('cacheable.unversioned-key')
         representation_headers = headers.slice(*ResponseBank::CACHEABLE_HEADERS)
@@ -26,6 +34,7 @@ module ResponseBank
         generated_at = timestamp.respond_to?(:call) ? timestamp.call : timestamp
         data = cache_data(status, representation_headers, stored, env, generated_at, content_encoding)
 
+        before_write&.call
         ResponseBank.write_to_cache(cache_key) do
           payload = MessagePack.dump(data)
           ResponseBank.write_to_backing_cache_store(

--- a/lib/response_bank/cache_writer.rb
+++ b/lib/response_bank/cache_writer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'response_bank/brotli_splice_slot'
+require 'response_bank/cache_policy'
 require 'msgpack'
 
 module ResponseBank
@@ -11,61 +12,92 @@ module ResponseBank
       def flatten(body)
         return body if body.is_a?(String)
 
-        result = +""
+        result = +''
         body.each { |part| result << part }
         result
       end
 
-      def store(env, status:, headers:, body:, timestamp:, content_encoding:, cacheable_headers:, on_prepared: nil)
-        body_compressed = nil
-        metadata = nil
-        if body && body != ""
-          env["cacheable.compression_level"] = ResponseBank.compression_level_for_request(env, headers)
-          time = ResponseBank.measure do
-            encoded_body = if content_encoding == 'br'
-              ResponseBank::BrotliSpliceSlot.encode_body(
-                env,
-                body,
-                headers,
-                compression_level: env["cacheable.compression_level"],
-              )
-            end
-
-            if encoded_body
-              body = encoded_body.body
-              body_compressed = encoded_body.compressed_body
-              metadata = encoded_body.metadata
-            else
-              body_compressed = ResponseBank.compress(
-                body,
-                content_encoding,
-                compression_level: env["cacheable.compression_level"],
-              )
-            end
-          end
-          ResponseBank.log("Compression time: #{time}ms")
-          env["cacheable.compression_time"] = time
-          headers['Content-Encoding'] = content_encoding
-        end
-
-        cached_headers = headers.slice(*cacheable_headers)
+      def store(env, status:, headers:, body:, timestamp:, content_encoding:)
+        cache_key = env.fetch('cacheable.key')
+        unversioned_key = env.fetch('cacheable.unversioned-key')
+        representation_headers = headers.slice(*ResponseBank::CACHEABLE_HEADERS)
+        representation_headers['ETag'] = %{"#{cache_key}"}
+        stored = prepare_body(env, representation_headers, body, content_encoding)
         generated_at = timestamp.respond_to?(:call) ? timestamp.call : timestamp
-        cache_data = [status, cached_headers, body_compressed, generated_at, env["cacheable.compression_level"]]
-        cache_data << metadata if metadata
+        data = cache_data(status, representation_headers, stored, env, generated_at, content_encoding)
 
-        stored = Stored.new(body: body, compressed_body: body_compressed, metadata: metadata)
-        on_prepared&.call(stored)
-        ResponseBank.write_to_cache(env['cacheable.key']) do
-          payload = MessagePack.dump(cache_data)
+        ResponseBank.write_to_cache(cache_key) do
+          payload = MessagePack.dump(data)
           ResponseBank.write_to_backing_cache_store(
             env,
-            env['cacheable.unversioned-key'],
+            unversioned_key,
             payload,
             expires_in: env['cacheable.versioned-cache-expiry'],
           )
         end
 
         stored
+      end
+
+      private
+
+      def prepare_body(env, headers, body, content_encoding)
+        body = flatten(body)
+        return Stored.new(body: body) if body.empty?
+
+        representation_headers = headers.merge('Content-Encoding' => content_encoding)
+        compression_level = ResponseBank.compression_level_for_request(env, representation_headers)
+        env['cacheable.compression_level'] = compression_level
+        body_compressed = nil
+        metadata = nil
+        time = ResponseBank.measure do
+          encoded_body = encode_spliced_body(
+            env,
+            body,
+            representation_headers,
+            content_encoding,
+            compression_level,
+          )
+
+          if encoded_body
+            body = encoded_body.body
+            body_compressed = encoded_body.compressed_body
+            metadata = encoded_body.metadata
+          else
+            body_compressed = ResponseBank.compress(
+              body,
+              content_encoding,
+              compression_level: compression_level,
+            )
+          end
+        end
+        ResponseBank.log("Compression time: #{time}ms")
+        env['cacheable.compression_time'] = time
+
+        Stored.new(body: body, compressed_body: body_compressed, metadata: metadata)
+      end
+
+      def encode_spliced_body(env, body, headers, content_encoding, compression_level)
+        return unless content_encoding == 'br'
+
+        ResponseBank::BrotliSpliceSlot.encode_body(
+          env,
+          body,
+          headers,
+          compression_level: compression_level,
+        )
+      end
+
+      def cache_data(status, representation_headers, stored, env, timestamp, content_encoding)
+        if stored.compressed_body
+          representation_headers['Content-Encoding'] = content_encoding
+        else
+          representation_headers.delete('Content-Encoding')
+        end
+        cached_headers = representation_headers.slice(*ResponseBank::CACHEABLE_HEADERS)
+        data = [status, cached_headers, stored.compressed_body, timestamp, env['cacheable.compression_level']]
+        data << stored.metadata if stored.metadata
+        data
       end
     end
   end

--- a/lib/response_bank/deferred_store.rb
+++ b/lib/response_bank/deferred_store.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'response_bank/cache_policy'
+require 'response_bank/cache_writer'
+
+module ResponseBank
+  class DeferredStore
+    ENV_KEY = 'response_bank.deferred_store'
+    LOCK_OWNED_ENV_KEY = 'response_bank.fill_lock_owned'
+    TERMINAL_STATES = %i[aborted completing consumed].freeze
+    PRIVATE_CACHE_DIRECTIVES = %w[private no-store].freeze
+
+    class InvalidContextError < ArgumentError; end
+    class StateError < StandardError; end
+
+    class << self
+      def create(env, timestamp:)
+        validate_context!(env)
+        raise InvalidContextError, 'a deferred store is already registered for this request' if env.key?(ENV_KEY)
+
+        new(env, timestamp: timestamp).tap { |store| env[ENV_KEY] = store }
+      end
+
+      def from_env(env)
+        env[ENV_KEY]
+      end
+
+      def arm_from_middleware(env, status:, headers:)
+        from_env(env)&.__send__(:arm, status: status, headers: headers)
+      end
+
+      private
+
+      def validate_context!(env)
+        raise InvalidContextError, 'deferred storage requires a cache miss' unless cache_miss?(env)
+        raise InvalidContextError, 'deferred storage requires a GET request' unless env['REQUEST_METHOD'] == 'GET'
+
+        ['cacheable.key', 'cacheable.unversioned-key', 'response_bank.server_cache_encoding'].each do |key|
+          raise InvalidContextError, "deferred storage requires #{key}" unless env[key]
+        end
+        unless env.key?(LOCK_OWNED_ENV_KEY)
+          raise InvalidContextError, "deferred storage requires #{LOCK_OWNED_ENV_KEY}"
+        end
+      end
+
+      def cache_miss?(env)
+        env['cacheable.cache'] && env['cacheable.miss']
+      end
+    end
+
+    def initialize(env, timestamp:)
+      @env = env
+      @timestamp = timestamp
+      @cache_key = env.fetch('cacheable.key')
+      @owns_lock = env.fetch(LOCK_OWNED_ENV_KEY) == true
+      @mutex = Mutex.new
+      @state = :requested
+    end
+
+    # `body` and `headers` must describe the complete shared cache representation,
+    # not a partial response or bytes personalized for the live client.
+    def complete(body:, headers: nil)
+      status, cached_headers, release_lock = prepare_completion(headers)
+
+      if release_lock
+        release_owned_lock
+        return false
+      end
+      return false unless status
+
+      write_started = false
+      completed = false
+      begin
+        CacheWriter.store(
+          @env,
+          status: status,
+          headers: cached_headers,
+          body: body,
+          timestamp: @timestamp,
+          before_write: -> { write_started = true },
+        )
+        completed = true
+      ensure
+        @mutex.synchronize { @state = :consumed }
+        @env['cacheable.locked'] = false if @owns_lock
+        release_owned_lock if @owns_lock && !completed && !write_started
+      end
+      true
+    end
+
+    def abort
+      transitioned, release_lock = @mutex.synchronize do
+        if TERMINAL_STATES.include?(@state)
+          [false, false]
+        else
+          @state = :aborted
+          [true, @owns_lock]
+        end
+      end
+
+      release_owned_lock if release_lock
+      transitioned
+    end
+
+    private
+
+    def arm(status:, headers:)
+      @mutex.synchronize do
+        if @state != :aborted
+          raise StateError, "cannot arm a deferred store in the #{@state} state" unless @state == :requested
+
+          @status = status
+          @headers = headers.slice(*ResponseBank::CACHEABLE_HEADERS)
+          @eligible = @owns_lock && cache_miss? && status_cacheable?(status)
+          @state = :armed
+        end
+      end
+
+      self
+    end
+
+    def prepare_completion(headers)
+      @mutex.synchronize do
+        raise StateError, 'the deferred store has not been armed by the middleware' if @state == :requested
+        return [nil, nil, false] if @state == :aborted
+        raise StateError, "cannot complete a deferred store in the #{@state} state" unless @state == :armed
+
+        cached_headers = (headers || @headers).slice(*ResponseBank::CACHEABLE_HEADERS)
+        if completion_eligible?(cached_headers)
+          @state = :completing
+          [@status, cached_headers, false]
+        else
+          @state = :aborted
+          [nil, nil, @owns_lock]
+        end
+      end
+    end
+
+    def completion_eligible?(headers)
+      @eligible && cache_miss? && cache_control_allows_storage?(headers)
+    end
+
+    def cache_miss?
+      @env['cacheable.cache'] && @env['cacheable.miss']
+    end
+
+    def status_cacheable?(status)
+      ResponseBank::CACHEABLE_STATUSES.include?(status)
+    end
+
+    def cache_control_allows_storage?(headers)
+      value = headers['Cache-Control']
+      return true unless value
+
+      directives = value.split(',').map { |directive| directive.strip.downcase.split('=', 2).first }
+      (directives & PRIVATE_CACHE_DIRECTIVES).empty?
+    end
+
+    def release_owned_lock
+      ResponseBank.release_lock(@cache_key)
+    ensure
+      @env['cacheable.locked'] = false
+    end
+  end
+end

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 require 'response_bank/brotli_splice_slot'
+require 'response_bank/cache_policy'
 require 'response_bank/cache_writer'
 
 module ResponseBank
   class Middleware
-    # Limit the cached headers
-    # TODO: Make this lowercase/case-insentitive as per rfc2616 §4.2
-    CACHEABLE_HEADERS = ["Location", "Content-Type", "ETag", "Content-Encoding", "Last-Modified", "Cache-Control", "Expires", "Link", "Surrogate-Keys", "Cache-Tags", "Speculation-Rules"].freeze
+    CACHEABLE_HEADERS = ResponseBank::CACHEABLE_HEADERS
+    CACHEABLE_STATUSES = ResponseBank::CACHEABLE_STATUSES
 
     REQUESTED_WITH = "HTTP_X_REQUESTED_WITH"
     ACCEPT = "HTTP_ACCEPT"
@@ -30,7 +30,7 @@ module ResponseBank
           headers['ETag'] = %{"#{env['cacheable.key']}"}
         end
 
-        if [200, 404, 301].include?(status) && env['cacheable.miss']
+        if CACHEABLE_STATUSES.include?(status) && env['cacheable.miss']
           body_string = CacheWriter.flatten(body)
           stored = nil
           begin
@@ -41,19 +41,17 @@ module ResponseBank
               body: body_string,
               timestamp: -> { timestamp },
               content_encoding: content_encoding,
-              cacheable_headers: CACHEABLE_HEADERS,
-              on_prepared: ->(result) { stored = result },
             )
 
             if stored.compressed_body
               if env['HTTP_ACCEPT_ENCODING'].to_s.include?(content_encoding)
+                headers['Content-Encoding'] = content_encoding
                 if content_encoding == 'br'
                   body = [ResponseBank::BrotliSpliceSlot.replace_compressed_secret(env, stored.compressed_body, stored.metadata)]
                 else
                   body = [stored.compressed_body]
                 end
               else
-                # Remove content-encoding header for response with compressed content
                 headers.delete('Content-Encoding')
                 body = [ResponseBank::BrotliSpliceSlot.replace_plain_body(env, stored.body, stored.metadata)] if stored.metadata
               end
@@ -99,6 +97,5 @@ module ResponseBank
     def timestamp
       Time.now.to_i
     end
-
   end
 end

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'response_bank/brotli_splice_slot'
+require 'response_bank/cache_writer'
 
 module ResponseBank
   class Middleware
@@ -30,78 +31,35 @@ module ResponseBank
         end
 
         if [200, 404, 301].include?(status) && env['cacheable.miss']
-          # Flatten down the result so that it can be stored to memcached.
-          if body.is_a?(String)
-            body_string = body
-          else
-            body_string = +""
-            body.each { |part| body_string << part }
-          end
-
+          body_string = CacheWriter.flatten(body)
+          stored = nil
           begin
-            body_compressed = nil
-          metadata = nil
-          if body_string && body_string != ""
-            env["cacheable.compression_level"] = ResponseBank.compression_level_for_request(env, headers)
-            time = ResponseBank.measure do
-              encoded_body = if content_encoding == 'br'
-                ResponseBank::BrotliSpliceSlot.encode_body(
-                  env,
-                  body_string,
-                  headers,
-                  compression_level: env["cacheable.compression_level"],
-                )
-              end
-
-              if encoded_body
-                body_string = encoded_body.body
-                body_compressed = encoded_body.compressed_body
-                metadata = encoded_body.metadata
-              else
-                body_compressed = ResponseBank.compress(
-                  body_string,
-                  content_encoding,
-                  compression_level: env["cacheable.compression_level"],
-                )
-              end
-            end
-            ResponseBank.log("Compression time: #{time}ms")
-            env["cacheable.compression_time"] = time
-            headers['Content-Encoding'] = content_encoding
-          end
-
-          cached_headers = headers.slice(*CACHEABLE_HEADERS)
-          # Store result
-          cache_data = [status, cached_headers, body_compressed, timestamp, env["cacheable.compression_level"]]
-          cache_data << metadata if metadata
-
-          ResponseBank.write_to_cache(env['cacheable.key']) do
-            payload = MessagePack.dump(cache_data)
-            ResponseBank.write_to_backing_cache_store(
+            stored = CacheWriter.store(
               env,
-              env['cacheable.unversioned-key'],
-              payload,
-              expires_in: env['cacheable.versioned-cache-expiry'],
+              status: status,
+              headers: headers,
+              body: body_string,
+              timestamp: -> { timestamp },
+              content_encoding: content_encoding,
+              cacheable_headers: CACHEABLE_HEADERS,
+              on_prepared: ->(result) { stored = result },
             )
-          end
 
-          # since we had to generate the compressed version already we may
-          # as well serve it if the client wants it
-          if body_compressed
-            if env['HTTP_ACCEPT_ENCODING'].to_s.include?(content_encoding)
-              if content_encoding == 'br'
-                body = [ResponseBank::BrotliSpliceSlot.replace_compressed_secret(env, body_compressed, metadata)]
+            if stored.compressed_body
+              if env['HTTP_ACCEPT_ENCODING'].to_s.include?(content_encoding)
+                if content_encoding == 'br'
+                  body = [ResponseBank::BrotliSpliceSlot.replace_compressed_secret(env, stored.compressed_body, stored.metadata)]
+                else
+                  body = [stored.compressed_body]
+                end
               else
-                body = [body_compressed]
+                # Remove content-encoding header for response with compressed content
+                headers.delete('Content-Encoding')
+                body = [ResponseBank::BrotliSpliceSlot.replace_plain_body(env, stored.body, stored.metadata)] if stored.metadata
               end
-            else
-              # Remove content-encoding header for response with compressed content
-              headers.delete('Content-Encoding')
-              body = [ResponseBank::BrotliSpliceSlot.replace_plain_body(env, body_string, metadata)] if metadata
-            end
             end
           rescue => exception
-            headers.delete('Content-Encoding') if body_compressed
+            headers.delete('Content-Encoding') if stored&.compressed_body
             ResponseBank.log("Failed to write to cache: #{exception.class} - #{exception.message}")
             if env['response_bank.on_exception']
               begin

--- a/lib/response_bank/middleware.rb
+++ b/lib/response_bank/middleware.rb
@@ -2,6 +2,7 @@
 require 'response_bank/brotli_splice_slot'
 require 'response_bank/cache_policy'
 require 'response_bank/cache_writer'
+require 'response_bank/deferred_store'
 
 module ResponseBank
   class Middleware
@@ -23,14 +24,21 @@ module ResponseBank
 
       content_encoding = env['response_bank.server_cache_encoding'] = ResponseBank.check_encoding(env)
 
-      status, headers, body = @app.call(env)
+      status, headers, body = begin
+        @app.call(env)
+      rescue StandardError
+        ResponseBank::DeferredStore.from_env(env)&.abort
+        raise
+      end
+      deferred_store = ResponseBank::DeferredStore.from_env(env)
+      ResponseBank::DeferredStore.arm_from_middleware(env, status: status, headers: headers)
 
       if env['cacheable.cache']
-        if [200, 404, 301, 304].include?(status)
+        if [200, 404, 301, 304].include?(status) && !deferred_store
           headers['ETag'] = %{"#{env['cacheable.key']}"}
         end
 
-        if CACHEABLE_STATUSES.include?(status) && env['cacheable.miss']
+        if CACHEABLE_STATUSES.include?(status) && env['cacheable.miss'] && !deferred_store
           body_string = CacheWriter.flatten(body)
           stored = nil
           begin

--- a/lib/response_bank/response_cache_handler.rb
+++ b/lib/response_bank/response_cache_handler.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'digest/md5'
 require 'response_bank/brotli_splice_slot'
+require 'response_bank/deferred_store'
 
 module ResponseBank
   class ResponseCacheHandler
@@ -144,6 +145,7 @@ module ResponseBank
           if ResponseBank.acquire_lock(match_entity_tag)
             # execute if we can get the lock
             @env['cacheable.locked'] = true
+            @env[ResponseBank::DeferredStore::LOCK_OWNED_ENV_KEY] = true
             return
           elsif stale_while_revalidate?(timestamp, cache_age_tolerance)
             # cache is being regenerated, can we avoid piling on and use a stale version in the interim?
@@ -208,8 +210,10 @@ module ResponseBank
     end
 
     def refill_cache
-      # non cache hits do not yet have the lock
-      ResponseBank.acquire_lock(entity_tag_hash) unless @env['cacheable.locked']
+      unless @env['cacheable.locked']
+        acquired = ResponseBank.acquire_lock(entity_tag_hash)
+        @env[ResponseBank::DeferredStore::LOCK_OWNED_ENV_KEY] = !!acquired
+      end
       @env['cacheable.locked'] = true
       @env['cacheable.miss'] = true
 

--- a/test/cache_writer_test.rb
+++ b/test/cache_writer_test.rb
@@ -2,6 +2,12 @@
 require File.dirname(__FILE__) + "/test_helper"
 
 class ResponseBankCacheWriterTest < Minitest::Test
+  class RewritingBody < Array
+    def each
+      super { |part| yield("#{part}!") }
+    end
+  end
+
   def setup
     @original_cache_store = ResponseBank.cache_store
     ResponseBank.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
@@ -64,6 +70,34 @@ class ResponseBankCacheWriterTest < Minitest::Test
       [301, { 'Location' => 'http://shopify.com', 'ETag' => '"etag_value"' }, nil, 424242, nil],
       payload,
     )
+  end
+
+  def test_store_does_not_copy_a_single_chunk_body
+    chunk = 'Hi'
+
+    stored = cache_writer.store(
+      @env,
+      status: 200,
+      headers: {},
+      body: [chunk],
+      timestamp: 424242,
+      content_encoding: 'br',
+    )
+
+    assert_same(chunk, stored.body)
+  end
+
+  def test_store_enumerates_an_array_subclass
+    stored = cache_writer.store(
+      @env,
+      status: 200,
+      headers: {},
+      body: RewritingBody.new(['Hi']),
+      timestamp: 424242,
+      content_encoding: 'br',
+    )
+
+    assert_equal('Hi!', stored.body)
   end
 
   def test_store_keeps_only_cacheable_headers

--- a/test/cache_writer_test.rb
+++ b/test/cache_writer_test.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+require File.dirname(__FILE__) + "/test_helper"
+
+class ResponseBankCacheWriterTest < Minitest::Test
+  def setup
+    @original_cache_store = ResponseBank.cache_store
+    ResponseBank.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
+    @env = Rack::MockRequest.env_for("http://example.com/index.html")
+    @env['response_bank.server_cache_encoding'] = 'br'
+    @env['cacheable.key'] = 'etag_value'
+    @env['cacheable.unversioned-key'] = 'store_cache_key'
+  end
+
+  def teardown
+    ResponseBank.cache_store = @original_cache_store
+  end
+
+  def test_store_copies_headers_and_adds_cache_representation_headers
+    headers = {
+      'Content-Type' => 'text/plain',
+      'ETag' => 'caller-etag',
+      'Content-Encoding' => 'gzip',
+    }.freeze
+
+    stored = cache_writer.store(
+      @env,
+      status: 200,
+      headers: headers,
+      body: ['Hi'],
+      timestamp: 424242,
+      content_encoding: 'br',
+    )
+
+    assert_equal('Hi', stored.body)
+    assert_equal(ResponseBank.compress('Hi', 'br'), stored.compressed_body)
+    payload = MessagePack.load(ResponseBank.cache_store.read('store_cache_key', raw: true))
+    assert_equal(
+      [
+        200,
+        { 'Content-Type' => 'text/plain', 'ETag' => '"etag_value"', 'Content-Encoding' => 'br' },
+        ResponseBank.compress('Hi', 'br'),
+        424242,
+        7,
+      ],
+      payload,
+    )
+  end
+
+  def test_store_writes_an_empty_body_without_content_encoding
+    headers = { 'Location' => 'http://shopify.com', 'Content-Encoding' => 'gzip' }.freeze
+
+    stored = cache_writer.store(
+      @env,
+      status: 301,
+      headers: headers,
+      body: [],
+      timestamp: 424242,
+      content_encoding: 'br',
+    )
+
+    assert_nil(stored.compressed_body)
+    payload = MessagePack.load(ResponseBank.cache_store.read('store_cache_key', raw: true))
+    assert_equal(
+      [301, { 'Location' => 'http://shopify.com', 'ETag' => '"etag_value"' }, nil, 424242, nil],
+      payload,
+    )
+  end
+
+  def test_store_keeps_only_cacheable_headers
+    cache_writer.store(
+      @env,
+      status: 200,
+      headers: {
+        'Content-Type' => 'text/plain',
+        'Cache-Tags' => 'tag1',
+        'Extra-Headers' => 'not-cached',
+      },
+      body: ['Hi'],
+      timestamp: 424242,
+      content_encoding: 'br',
+    )
+
+    payload = MessagePack.load(ResponseBank.cache_store.read('store_cache_key', raw: true))
+    assert_equal(
+      {
+        'Content-Type' => 'text/plain',
+        'ETag' => '"etag_value"',
+        'Content-Encoding' => 'br',
+        'Cache-Tags' => 'tag1',
+      },
+      payload[1],
+    )
+  end
+
+  private
+
+  def cache_writer
+    ResponseBank.const_get(:CacheWriter, false)
+  end
+end

--- a/test/deferred_store_test.rb
+++ b/test/deferred_store_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+require File.dirname(__FILE__) + "/test_helper"
+
+class ResponseBankDeferredStoreTest < Minitest::Test
+  def setup
+    @original_cache_store = ResponseBank.cache_store
+    ResponseBank.cache_store = ActiveSupport::Cache.lookup_store(:memory_store)
+    @env = Rack::MockRequest.env_for("http://example.com/index.html")
+    @env['response_bank.server_cache_encoding'] = 'br'
+    @env['cacheable.cache'] = true
+    @env['cacheable.miss'] = true
+    @env['cacheable.locked'] = true
+    @env[ResponseBank::DeferredStore::LOCK_OWNED_ENV_KEY] = true
+    @env['cacheable.key'] = 'etag_value'
+    @env['cacheable.unversioned-key'] = 'store_cache_key'
+  end
+
+  def teardown
+    ResponseBank.cache_store = @original_cache_store
+  end
+
+  def test_defer_store_requires_an_initialized_cache_miss
+    @env.delete('cacheable.key')
+
+    error = assert_raises(ResponseBank::DeferredStore::InvalidContextError) do
+      ResponseBank.defer_store(@env)
+    end
+
+    assert_includes(error.message, 'cacheable.key')
+  end
+
+  def test_defer_store_rejects_non_get_requests
+    %w[HEAD POST].each do |method|
+      @env['REQUEST_METHOD'] = method
+
+      assert_raises(ResponseBank::DeferredStore::InvalidContextError) do
+        ResponseBank.defer_store(@env)
+      end
+    end
+  end
+
+  def test_complete_requires_the_middleware_to_arm_the_store
+    store = ResponseBank.defer_store(@env)
+
+    assert_raises(ResponseBank::DeferredStore::StateError) do
+      store.complete(headers: {}, body: 'Hi')
+    end
+  end
+
+  def test_complete_is_one_shot_and_abort_after_completion_is_a_no_op
+    store = ResponseBank.defer_store(@env, timestamp: 424242)
+    ResponseBank::DeferredStore.arm_from_middleware(
+      @env,
+      status: 200,
+      headers: { 'Content-Type' => 'text/plain' },
+    )
+    ResponseBank.expects(:release_lock).never
+
+    assert(store.complete(body: 'Hi'))
+    refute(store.abort)
+    assert_raises(ResponseBank::DeferredStore::StateError) do
+      store.complete(body: 'Hi again')
+    end
+  end
+
+  def test_abort_releases_an_owned_lock_once
+    store = ResponseBank.defer_store(@env)
+    ResponseBank::DeferredStore.arm_from_middleware(@env, status: 200, headers: {})
+    ResponseBank.cache_store.expects(:write).never
+    ResponseBank.expects(:release_lock).with('etag_value').once
+
+    assert(store.abort)
+    refute(store.abort)
+    refute(store.complete(headers: {}, body: 'Hi'))
+    assert_equal(false, @env['cacheable.locked'])
+  end
+
+  def test_complete_releases_the_lock_when_compression_fails_before_the_write_hook
+    store = ResponseBank.defer_store(@env)
+    ResponseBank::DeferredStore.arm_from_middleware(@env, status: 200, headers: {})
+    ResponseBank.stubs(:compress).raises(StandardError, 'compression failed')
+    ResponseBank.expects(:write_to_cache).never
+    ResponseBank.expects(:release_lock).with('etag_value').once
+
+    assert_raises(StandardError) do
+      store.complete(headers: {}, body: 'Hi')
+    end
+    refute(store.abort)
+  end
+
+  def test_complete_aborts_when_rendering_disables_caching
+    store = ResponseBank.defer_store(@env)
+    ResponseBank::DeferredStore.arm_from_middleware(@env, status: 200, headers: {})
+    @env['cacheable.cache'] = false
+    ResponseBank.cache_store.expects(:write).never
+    ResponseBank.expects(:release_lock).with('etag_value').once
+
+    refute(store.complete(headers: {}, body: 'Hi'))
+    refute(store.abort)
+  end
+
+  def test_complete_rejects_private_cache_control_from_armed_headers
+    store = ResponseBank.defer_store(@env)
+    ResponseBank::DeferredStore.arm_from_middleware(
+      @env,
+      status: 200,
+      headers: { 'Cache-Control' => 'private="Set-Cookie"' },
+    )
+    ResponseBank.cache_store.expects(:write).never
+    ResponseBank.expects(:release_lock).with('etag_value').once
+
+    refute(store.complete(body: 'Hi'))
+  end
+
+  def test_complete_rejects_no_store_in_final_cached_headers
+    store = ResponseBank.defer_store(@env)
+    ResponseBank::DeferredStore.arm_from_middleware(@env, status: 200, headers: {})
+    ResponseBank.cache_store.expects(:write).never
+    ResponseBank.expects(:release_lock).with('etag_value').once
+
+    refute(store.complete(headers: { 'Cache-Control' => 'public, no-store' }, body: 'Hi'))
+  end
+
+  def test_write_hook_owns_cleanup_after_a_write_attempt_fails
+    store = ResponseBank.defer_store(@env)
+    ResponseBank::DeferredStore.arm_from_middleware(@env, status: 200, headers: {})
+    ResponseBank.stubs(:write_to_cache).raises(StandardError, 'write failed')
+    ResponseBank.expects(:release_lock).never
+
+    assert_raises(StandardError) do
+      store.complete(headers: {}, body: 'Hi')
+    end
+    refute(store.abort)
+  end
+
+  def test_complete_does_not_store_or_release_without_the_fill_lock
+    @env['cacheable.locked'] = false
+    @env[ResponseBank::DeferredStore::LOCK_OWNED_ENV_KEY] = false
+    store = ResponseBank.defer_store(@env)
+    ResponseBank::DeferredStore.arm_from_middleware(@env, status: 200, headers: {})
+    ResponseBank.cache_store.expects(:write).never
+    ResponseBank.expects(:release_lock).never
+
+    refute(store.complete(headers: {}, body: 'Hi'))
+  end
+end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -312,6 +312,17 @@ class MiddlewareTest < Minitest::Test
     assert(!headers['Content-Encoding'])
   end
 
+  def test_cache_writer_does_not_use_the_write_hook_return_value
+    ResponseBank.stubs(:write_to_cache).yields.returns(nil)
+
+    ware = ResponseBank::Middleware.new(method(:cacheable_app))
+    status, headers, body = ware.call(@env)
+
+    assert_equal(200, status)
+    assert_equal('br', headers['Content-Encoding'])
+    assert_equal('Hi', Brotli.inflate(body.first))
+  end
+
   def test_cache_miss_and_store_with_custom_brotli_compression_level_block
     ResponseBank.compression_level = ->(env, headers) { 1 }
     ResponseBank::Middleware.any_instance.stubs(timestamp: 424242)

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -121,6 +121,22 @@ def already_cached_app(env)
   [200, { 'Content-Type' => 'text/plain' }, body]
 end
 
+def prepare_deferred_cache_miss(env)
+  env['cacheable.cache'] = true
+  env['cacheable.miss'] = true
+  env['cacheable.locked'] = true
+  env[ResponseBank::DeferredStore::LOCK_OWNED_ENV_KEY] = true
+  env['cacheable.key'] = 'etag_value'
+  env['cacheable.unversioned-key'] = 'deferred_store_app_cache_key'
+end
+
+def deferred_store_app(env)
+  prepare_deferred_cache_miss(env)
+  env['test.deferred_store'] = ResponseBank.defer_store(env, timestamp: 424242)
+
+  [200, { 'Content-Type' => 'text/plain', 'rack.hijack' => proc {} }, []]
+end
+
 def client_hit_app(env)
   env['cacheable.cache'] = true
   env['cacheable.miss']  = false
@@ -177,6 +193,39 @@ class OffsetHtmlMetadataInjector
       suffix = slot.fetch('context_suffix', CONTEXT_SUFFIX)
       current.byteslice(0, offset) + replacement + suffix + current.byteslice(offset + length, current.bytesize)
     end
+  end
+end
+
+class DeferredLifecycleApp
+  attr_reader :deferred_store, :render_count
+
+  def initialize
+    @render_count = 0
+  end
+
+  def call(env)
+    handler = ResponseBank::ResponseCacheHandler.new(
+      key_data: { path: '/deferred' },
+      version_data: { version: 1 },
+      env: env,
+      cache_age_tolerance: 0,
+      serve_unversioned: false,
+      headers: {},
+    ) do
+      @render_count += 1
+      @deferred_store = ResponseBank.defer_store(env, timestamp: 424242)
+      [
+        200,
+        {
+          'Content-Type' => 'text/html',
+          'Cache-Control' => 'no-cache, no-store',
+          'rack.hijack' => proc {},
+        },
+        [],
+      ]
+    end
+
+    handler.run!
   end
 end
 
@@ -672,5 +721,135 @@ class MiddlewareTest < Minitest::Test
     # Should still return 200 OK even if exception handler fails
     assert_equal(200, result[0])
     assert_equal('Hi', result[2].join)
+  end
+
+  def test_cache_miss_arms_a_deferred_store_without_emitting_an_etag
+    ResponseBank.cache_store.expects(:write).never
+
+    ware = ResponseBank::Middleware.new(method(:deferred_store_app))
+    status, headers, body = ware.call(@env)
+
+    assert_equal(200, status)
+    assert_nil(headers['ETag'])
+    assert_equal('miss', headers['X-Cache'])
+    assert_equal([], body)
+    assert_nil(headers['Content-Encoding'])
+    assert_nil(@env['cacheable.compression_level'])
+  end
+
+  def test_middleware_tolerates_a_deferred_store_aborted_before_arming
+    app = lambda do |env|
+      prepare_deferred_cache_miss(env)
+      store = ResponseBank.defer_store(env)
+      store.abort
+      [200, { 'Content-Type' => 'text/plain' }, ['fallback']]
+    end
+    ResponseBank.cache_store.expects(:write).never
+    ResponseBank.expects(:release_lock).with('etag_value').once
+
+    status, headers, body = ResponseBank::Middleware.new(app).call(@env)
+
+    assert_equal(200, status)
+    assert_nil(headers['ETag'])
+    assert_equal(['fallback'], body)
+  end
+
+  def test_middleware_aborts_a_deferred_store_when_the_app_raises
+    app = lambda do |env|
+      prepare_deferred_cache_miss(env)
+      ResponseBank.defer_store(env)
+      raise StandardError, 'render failed'
+    end
+    ResponseBank.expects(:release_lock).with('etag_value').once
+
+    error = assert_raises(StandardError) do
+      ResponseBank::Middleware.new(app).call(@env)
+    end
+
+    assert_equal('render failed', error.message)
+  end
+
+  def test_deferred_store_writes_copied_headers_with_etag_and_captured_timestamp
+    ware = ResponseBank::Middleware.new(method(:deferred_store_app))
+    _status, live_headers, = ware.call(@env)
+    cached_headers = { 'Content-Type' => 'text/plain' }
+
+    stored = @env.fetch('test.deferred_store').complete(headers: cached_headers, body: 'Hi')
+
+    assert(stored)
+    assert_equal({ 'Content-Type' => 'text/plain' }, cached_headers)
+    assert_nil(live_headers['ETag'])
+    payload = MessagePack.load(ResponseBank.cache_store.read('deferred_store_app_cache_key', raw: true))
+    status, headers, body, timestamp, compression_level = payload
+    assert_equal(200, status)
+    assert_equal(
+      { 'Content-Type' => 'text/plain', 'ETag' => '"etag_value"', 'Content-Encoding' => 'br' },
+      headers,
+    )
+    assert_equal('Hi', Brotli.inflate(body))
+    assert_equal(424242, timestamp)
+    assert_equal(7, compression_level)
+  end
+
+  def test_deferred_miss_completion_is_served_by_following_cache_hits
+    ResponseBank.stubs(:acquire_lock).returns(true)
+    app = DeferredLifecycleApp.new
+    injector = lambda do |env|
+      OffsetHtmlMetadataInjector.new(
+        placeholder: '00000000-0000-0000-0000-000000000000',
+        replacement: env.fetch('HTTP_SHOPIFY_Y'),
+      )
+    end
+    ware = ResponseBank::Middleware.new(app, injector)
+    first_env = request_env(encoding: 'br', shopify_y: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+    first_status, first_headers, = ware.call(first_env)
+
+    assert_equal(200, first_status)
+    assert_nil(first_headers['ETag'])
+    assert_equal('no-cache, no-store', first_headers['Cache-Control'])
+    assert_equal('miss', first_headers['X-Cache'])
+    assert(
+      app.deferred_store.complete(
+        headers: { 'Content-Type' => 'text/html' },
+        body: '<html><head></head><body>Hi</body></html>',
+      ),
+    )
+
+    br_status, br_headers, br_body = ware.call(
+      request_env(encoding: 'br', shopify_y: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
+    )
+    assert_equal(200, br_status)
+    assert_equal('hit, server', br_headers['X-Cache'])
+    assert_equal('br', br_headers['Content-Encoding'])
+    assert_includes(Brotli.inflate(br_body.first), 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb')
+    refute_includes(Brotli.inflate(br_body.first), 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa')
+
+    plain_status, plain_headers, plain_body = ware.call(
+      request_env(encoding: nil, shopify_y: 'cccccccc-cccc-cccc-cccc-cccccccccccc'),
+    )
+    assert_equal(200, plain_status)
+    assert_equal('hit, server', plain_headers['X-Cache'])
+    assert_nil(plain_headers['Content-Encoding'])
+    assert_includes(plain_body.first, 'cccccccc-cccc-cccc-cccc-cccccccccccc')
+
+    etag = plain_headers.fetch('ETag')
+    conditional_env = request_env(encoding: nil, shopify_y: 'dddddddd-dddd-dddd-dddd-dddddddddddd')
+    conditional_env['HTTP_IF_NONE_MATCH'] = etag
+    conditional_status, conditional_headers, conditional_body = ware.call(conditional_env)
+    assert_equal(304, conditional_status)
+    assert_equal(etag, conditional_headers['ETag'])
+    assert_equal('hit, client', conditional_headers['X-Cache'])
+    assert_equal([], conditional_body)
+    assert_equal(1, app.render_count)
+  end
+
+  private
+
+  def request_env(encoding:, shopify_y:)
+    Rack::MockRequest.env_for('http://example.com/deferred').tap do |env|
+      env['HTTP_ACCEPT_ENCODING'] = encoding if encoding
+      env['HTTP_SHOPIFY_Y'] = shopify_y
+    end
   end
 end

--- a/test/response_cache_handler_test.rb
+++ b/test/response_cache_handler_test.rb
@@ -101,6 +101,7 @@ class ResponseCacheHandlerTest < Minitest::Test
     _, _, body = handler.run!
     assert_equal('dynamic output', body)
     assert_cache_miss(true, nil)
+    assert_equal(true, controller.request.env[ResponseBank::DeferredStore::LOCK_OWNED_ENV_KEY])
   end
 
   def test_client_cache_hit
@@ -278,6 +279,7 @@ class ResponseCacheHandlerTest < Minitest::Test
     handler.run!
 
     assert_cache_miss(true, :anything)
+    assert_equal(false, controller.request.env[ResponseBank::DeferredStore::LOCK_OWNED_ENV_KEY])
   end
 
   def test_server_recent_cache_miss
@@ -345,9 +347,7 @@ class ResponseCacheHandlerTest < Minitest::Test
     assert_equal(true, controller.request.env['cacheable.cache'])
     assert_equal(miss, controller.request.env['cacheable.miss'])
 
-    if (miss)
-      assert_equal(true, controller.request.env['cacheable.locked'])
-    end
+    assert_equal(true, controller.request.env['cacheable.locked']) if miss
 
     if store.nil?
       assert_nil(controller.request.env['cacheable.store'])


### PR DESCRIPTION
Adds `ResponseBank.defer_store`, a one-shot handle for completing a real cache miss after the Rack tuple returns.

## Why

`ResponseBank::Middleware` can store a response only when its body is complete as the Rack stack unwinds. A partial-hijack response returns an empty Rack body and writes its document later, so the normal middleware write cannot cache that document.

## Lifecycle

The application opens a deferred fill while it is handling a ResponseBank GET miss:

```ruby
deferred_store = ResponseBank.defer_store(env)
```

The middleware arms the handle after the application returns its status and headers. The application later supplies the complete shared representation:

```ruby
deferred_store.complete(headers: cache_headers, body: completed_body)
```

The response-finished path calls `deferred_store.abort`. Abort is idempotent and becomes a no-op after completion. It releases an owned fill through the optional `ResponseBank.release_lock` hook when the body never reaches the write hook.

## Safety and HTTP behavior

- Deferral requires an initialized ResponseBank GET miss and logical fill-lock ownership from `ResponseCacheHandler`.
- The handle captures the generation timestamp when deferral starts and rechecks cacheability when it completes.
- A deferred live response does not emit an ETag. The completed cache entry receives the ETag before it can be served.
- Cache writes build a separate header set. They do not add `Content-Encoding` to the caller's live headers.
- Cached headers retain the existing title-case header contract. ResponseBank controls the stored ETag and content encoding.
- Deferred completion rejects final cache headers containing `private` or `no-store`.
- Callers must complete only after the intended shared response was generated and written successfully. Failed, timed-out, disconnected, truncated, and client-specific representations must be aborted.
- The existing synchronous middleware behavior and MessagePack cache-entry format stay compatible.

## Brotli splice and body handling

Deferred completion uses the same Brotli splice writer as synchronous misses. It stores the neutral representation and metadata so each cache hit can insert its request-specific value.

A one-element Array body containing a String keeps that String without rebuilding the document. Array subclasses still use `each`, because they can override enumeration.

## Commit structure

The branch is split so the code move can be reviewed separately from each behavior change:

1. `dd41d45` extracts cache writing from the middleware without changing body enumeration, timestamp timing, callback inputs, header mutation, exception boundaries, serialization timing, or the cache payload.
2. `6e518f2` separates cached headers from live response headers while retaining the existing header-name contract.
3. `a1a322b` adds the one-shot deferred-fill lifecycle, its documentation, and its end-to-end coverage.
4. `789469b` isolates the one-element Array body optimization and its tests.

The full ResponseBank suite passes at every commit.

## Review follow-up

The first revision exposed a general `ResponseBank.store` method plus a mutable deferral flag. The reviews correctly identified that this made lifecycle order, completeness, headers, ETag setup, and lock cleanup too easy to misuse.

This revision addresses that feedback as follows:

- The general write method and boolean flag are replaced by a request-scoped, one-shot `DeferredStore` handle.
- The middleware captures the committed status and base cache headers before completion is allowed.
- Completion validates miss state, cacheability, method, status, required keys, and logical lock ownership.
- Cached headers are copied. Live headers are not relabeled for cached bytes.
- The live deferred response has no ETag. The cached ETag is synthesized internally after successful completion.
- The README states the complete-response and shared-representation requirements, including failure and disconnect paths.
- Constants and cache policy moved below the middleware boundary, with middleware aliases retained.
- The end-to-end test covers deferred miss, completion, Brotli splice metadata, encoded and identity hits, and a following conditional 304.
- A transparent hijack tee was not selected because wire bytes are not always the shared cache representation. Storefront sends request-specific metadata on the wire and caches a neutral document with late cache headers.

## Validation

- ResponseBank: 94 tests and 483 assertions passed after rebasing on `main`.
- The deferred lifecycle test covers Brotli and identity cache hits plus ETag behavior.
- Storefront Renderer consumer tests cover successful completion, timeout, disconnect, cache disablement, client-token isolation, and exactly-once lock release.
- Storefront Renderer `dev check` passed, including RuboCop, typecheck, Tapioca verification, and slice coverage.
