### PR TITLE
fix: Add "benchmark" as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     response_bank (1.3.8)
+      benchmark
       brotli
       msgpack
 

--- a/response_bank.gemspec
+++ b/response_bank.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("msgpack")
   s.add_runtime_dependency("brotli")
+  s.add_runtime_dependency("benchmark")
 
   # brotli_splice is optional for consumers: only apps that opt into Brotli splice
   # slots need this native extension, so it is not a runtime dependency (they add it


### PR DESCRIPTION
Ruby 4 does not include "benchmark", so this line fails with a LoadError.

https://github.com/Shopify/response_bank/blob/6baab69d9ec47ecda641434e4c8290f0118d64a1/lib/response_bank.rb#L9

Adding it as a runtime dependency to resolve the error.


# Deploy error logs:

```
#23 1.544 Caused by:
#23 1.589 LoadError: cannot load such file -- benchmark (LoadError)
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/bootsnap-1.24.6/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in 'Kernel#require'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/zeitwerk-2.8.2/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel#require'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/response_bank-1.3.8/lib/response_bank.rb:9:in '<main>'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/zeitwerk-2.8.2/lib/zeitwerk/core_ext/kernel.rb:34:in 'Kernel.require'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/bundler-4.0.18/lib/bundler/runtime.rb:63:in 'block (2 levels) in Bundler::Runtime#require'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/bundler-4.0.18/lib/bundler/runtime.rb:58:in 'Array#each'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/bundler-4.0.18/lib/bundler/runtime.rb:58:in 'block in Bundler::Runtime#require'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/bundler-4.0.18/lib/bundler/runtime.rb:52:in 'Array#each'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/bundler-4.0.18/lib/bundler/runtime.rb:52:in 'Bundler::Runtime#require'
#23 1.589 /usr/local/bundle/ruby/4.0.0/gems/bundler-4.0.18/lib/bundler.rb:214:in 'Bundler.require'
#23 1.589 /rails/config/application.rb:10:in '<main>'
#23 1.589 /rails/Rakefile:5:in 'Kernel#require_relative'
#23 1.589 /rails/Rakefile:5:in '<main>'
```