### PR TITLE
Bump version to 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.4.0] - 2026-08-11
 
 ### Added
 - `ResponseBank.defer_store`, which returns a one-shot handle for completing or
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Releases prior to 1.3.8 are recorded in the project's git tags and GitHub Releases.
 
+[1.4.0]: https://github.com/Shopify/response_bank/releases/tag/v1.4.0
 [1.3.8]: https://github.com/Shopify/response_bank/releases/tag/v1.3.8
 [#102]: https://github.com/Shopify/response_bank/pull/102
 [#103]: https://github.com/Shopify/response_bank/pull/103

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    response_bank (1.3.8)
+    response_bank (1.4.0)
       benchmark
       brotli
       msgpack

--- a/lib/response_bank/version.rb
+++ b/lib/response_bank/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ResponseBank
-  VERSION = "1.3.8"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
Bumps `response_bank` from 1.3.8 to 1.4.0.

## What's new since 1.3.8

- Adds a one-shot deferred cache-fill handle for responses that finish after the Rack tuple returns (#112).
- Separates cached response headers from live response headers.
- Adds the cached ETag only after a deferred fill completes successfully.
- Documents completeness, cacheability, and fill-lock ownership requirements.
- Avoids rebuilding one-element Array bodies before compression.

## Changes in this PR

- Updates `ResponseBank::VERSION` from 1.3.8 to 1.4.0.
- Updates the `Gemfile.lock` self-reference.
- Finalizes the 1.4.0 changelog entry with the release date and tag link.

## Why

Storefront Renderer needs a tagged release of the deferred cache-fill API so it can replace its commit pin.

Intended follow-up after merge: tag `v1.4.0` on `main`.

## Validation

- 94 tests and 483 assertions pass.
- `response_bank-1.4.0.gem` builds successfully.
